### PR TITLE
fix: redirect console.log to stderr to prevent MCP JSON-RPC corruption

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
+
+// Redirect console.log to stderr BEFORE any imports.
+// GramJS Logger uses console.log (stdout) which corrupts MCP JSON-RPC stream.
+const _origLog = console.log;
+console.log = (...args: unknown[]) => {
+  console.error(...args);
+};
+
 import "dotenv/config";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";


### PR DESCRIPTION
## Summary
- Redirects `console.log` to `console.error` (stderr) before any imports load
- GramJS Logger uses `console.log` internally, which writes ANSI-colored log output to stdout — this corrupts the MCP JSON-RPC stream over stdio transport
- The redirect is placed before all imports so it catches GramJS initialization logs as well

Closes #1

## Test plan
- [ ] Run `@overpod/mcp-telegram` in Claude Desktop — no more `SyntaxError: Unexpected token` JSON parse errors
- [ ] Verify MCP tools work correctly (list-chats, read-messages, etc.)
- [ ] Check stderr for redirected GramJS log output (should appear there instead of stdout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)