### PR TITLE
Add TELEGRAM_USE_WSS env-var to enable port-443 MTProto transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ npx @overpod/mcp-telegram
 | `TELEGRAM_PROXY_USERNAME` | Optional proxy auth |
 | `TELEGRAM_PROXY_PASSWORD` | Optional proxy auth |
 
+### Connecting via WSS (port 443)
+
+If your VPS or hosting IP is reachable on outbound port `443` but not the default MTProto port `80` (some cloud providers ban port `80` on Telegram DC IP ranges as anti-abuse policy), set:
+
+```bash
+TELEGRAM_USE_WSS=true npx @overpod/mcp-telegram
+```
+
+| Variable | Description |
+|----------|-------------|
+| `TELEGRAM_USE_WSS` | When `true`, gramJS uses port `443` instead of `80` for the MTProto TCPFull transport. Cannot be combined with `TELEGRAM_PROXY_*` (gramJS limitation). |
+
 ## Installation Options
 
 ### npx (recommended, zero install)

--- a/src/telegram-client.ts
+++ b/src/telegram-client.ts
@@ -322,6 +322,7 @@ export class TelegramService {
     const proxy = resolveProxy();
     this.client = new TelegramClient(session, this.apiId, this.apiHash, {
       connectionRetries: 5,
+      useWSS: process.env.TELEGRAM_USE_WSS === "true",
       ...(proxy && { proxy }),
     });
 
@@ -448,6 +449,7 @@ export class TelegramService {
     const proxy = resolveProxy();
     const client = new TelegramClient(session, this.apiId, this.apiHash, {
       connectionRetries: 5,
+      useWSS: process.env.TELEGRAM_USE_WSS === "true",
       ...(proxy && { proxy }),
     });
 


### PR DESCRIPTION
## Problem

Some hosting providers (notably Hostinger US, OVH and similar shared-VPS ranges) have outbound TCP/80 to Telegram DC IP-blocks blocked or actively dropped at the network level — apparently as anti-abuse policy after their ranges were used for spam/userbot farms. Reaching the same DC IPs on TCP/443 still works.

The default gramJS MTProto TCPFull transport connects on port `80`, so on these hosts mcp-telegram hangs forever in:

```
[INFO] - [Connecting to 149.154.167.51:80/TCPFull...]
```

Until now the only workaround was running an external SOCKS5/MTProxy somewhere with a non-banned IP. That's overkill — gramJS already supports the same transport on port 443 via a boolean flag, but mcp-telegram hard-codes it to `false`.

## Change

Expose [gramJS's `useWSS`](https://gram.js.org/beta/classes/Network.MTProtoSender.html) through a new env-var `TELEGRAM_USE_WSS`. Default is `false`, preserving current behaviour. Setting `TELEGRAM_USE_WSS=true` switches the TCPFull transport to port 443.

Two-line change in `src/telegram-client.ts` (both `TelegramClient` constructors), plus README documentation.

## Verification

Tested on a banned VPS-IP where TCP/80 connections to `149.154.167.51` (DC2) were dropped before MTProto handshake:

| Run | Result |
|---|---|
| Default (no env) — port 80 | hangs forever in `Connecting to 149.154.167.51:80/TCPFull...` |
| `TELEGRAM_USE_WSS=true` — port 443 | `Connection complete` in 47ms; full read+auth round-trip in 744ms |

A side note documented in the README: gramJS throws `Cannot use SSL with proxies` when `useWSS=true` is combined with `TELEGRAM_PROXY_*`. This is gramJS's own constraint, not introduced here.

## Out of scope

- This doesn't change the default — existing setups are unaffected.
- This doesn't help if Telegram has banned MTProto from your IP entirely (separate policy from per-port DC bans).