### PR TITLE
feat: shared daemon (serve mode) for concurrent MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ claude mcp add telegram-personal -s user \
 
 Each account gets its own session file — no conflicts.
 
+### Multiple agents / concurrent clients (shared daemon)
+
+The opposite of multiple accounts: **one** account driven by **many** clients at once — several Claude Code windows, parallel sub-agents, or multiple IDEs. Normally each process opens the same session and they evict one another with `AUTH_KEY_DUPLICATED`. Serve mode fixes this.
+
+Run a single persistent **daemon** that owns the one Telegram connection. Every other process auto-detects the daemon (via a PID lock) and becomes a thin client that proxies tool calls to it over a local Unix socket:
+
+```bash
+# On the host, once: start the daemon (owns the connection, no stdio)
+TELEGRAM_API_ID=YOUR_ID TELEGRAM_API_HASH=YOUR_HASH mcp-telegram serve
+# (or set MCP_TELEGRAM_DAEMON=1 instead of the `serve` argument)
+```
+
+Then point each MCP client at the same install with the same `TELEGRAM_SESSION_PATH` — no `serve` argument. They connect to the daemon automatically; closing any client never drops the shared connection. Credentials are only required by the daemon (the owner), so client commands can omit `TELEGRAM_API_ID`/`TELEGRAM_API_HASH` and keep them where the daemon runs.
+
+See the **[shared daemon guide](docs/guides/shared-daemon.md)** for a systemd unit and SSH usage.
+
 ### Proxy Support
 
 If Telegram is blocked or you're running in a containerized environment (Docker, K3s), use a SOCKS5 or MTProxy:

--- a/docs/guides/shared-daemon.md
+++ b/docs/guides/shared-daemon.md
@@ -1,0 +1,110 @@
+# Shared daemon (serve mode)
+
+By default each MCP client (each Claude Code window) launches its own `mcp-telegram` process,
+and each opens the **same** Telegram session file. Telegram allows only one live connection per
+session, so a second process evicts the first with `AUTH_KEY_DUPLICATED` — multiple windows end
+up fighting over the connection.
+
+**Serve mode** fixes this. One persistent daemon owns the single Telegram connection and listens
+on a Unix socket; every other process becomes a thin **client** that proxies tool calls to it over
+that socket. Many windows then share one connection safely, and closing any window never drops the
+connection.
+
+```
+window 1 ── ssh ─┐
+window 2 ── ssh ─┼─→  mcp-telegram (client) ──┐
+window 3 ── ssh ─┘                            │  Unix socket
+                                              ▼  /…/daemon.sock
+                              mcp-telegram serve (daemon, systemd)
+                                              │
+                                              ▼  single MTProto connection
+                                          Telegram
+```
+
+## How mode is selected
+
+`src/index.ts` dispatches at startup:
+
+- `mcp-telegram serve` (or env `MCP_TELEGRAM_DAEMON=1`) → **daemon** (`runServe`): owns the
+  connection, listens on the socket, no stdio attached, runs until `SIGTERM`.
+- otherwise it calls `tryAcquireLock()`:
+  - lock acquired → **master** (`runMaster`): owns the connection **and** serves the launching
+    window over stdio (the single-window / no-daemon path).
+  - lock held by a daemon/master → **client** (`runClient`): serves its window over stdio and
+    proxies every tool call to the owner via the IPC socket.
+
+The socket and lock live next to the session file:
+`dirname(TELEGRAM_SESSION_PATH)/daemon.sock` and `…/daemon.lock`.
+
+Internally `runMaster` and `runServe` share one `startOwner()` core (socket server + IPC dispatch
++ auto-connect + graceful shutdown); serve mode is that core without a stdio transport.
+
+## Server setup (systemd)
+
+Templates ship in [`packaging/`](../../packaging/).
+
+```bash
+# 1. Build
+npm ci && npm run build           # produces dist/
+
+# 2. Credentials server-side (clients won't need them)
+cp packaging/mcp-telegram.env.example /etc/mcp-telegram.env
+#   fill TELEGRAM_API_ID / TELEGRAM_API_HASH / TELEGRAM_SESSION_PATH
+chmod 600 /etc/mcp-telegram.env
+
+# 3. systemd unit (adjust the node + dist path in ExecStart)
+cp packaging/mcp-telegram.service /etc/systemd/system/mcp-telegram.service
+systemctl daemon-reload
+systemctl enable --now mcp-telegram
+
+# 4. Verify
+systemctl status mcp-telegram
+journalctl -u mcp-telegram -n 30   # expect "[serve] connected as @…"
+```
+
+The session file must already be authenticated (run `mcp-telegram login` once before starting the
+daemon). The daemon loads it on boot; it never logs in interactively per request.
+
+## Client setup
+
+Point the MCP server command at the same build; it becomes a client automatically because the
+daemon holds the lock. Credentials are optional for clients (only the daemon needs them). Over SSH:
+
+```jsonc
+// MCP client config (e.g. ~/.claude.json → mcpServers.telegram)
+{
+  "command": "ssh",
+  "args": [
+    "-T", "-o", "BatchMode=yes",
+    "user@host",
+    "TELEGRAM_SESSION_PATH=/path/to/session node /path/to/dist/cli.js"
+  ]
+}
+```
+
+`TELEGRAM_SESSION_PATH` is required so the client resolves the daemon's socket path. Avoid
+redirecting the remote command's stderr to `/dev/null` — that hides the diagnostics you need when
+something breaks.
+
+## Observability
+
+The daemon logs to stderr (captured by journald):
+
+- `[serve] connected as @…` — the single connection is up.
+- `[serve] client connected` / `client disconnected` — a client attached / detached.
+
+A client disconnect tears down only that client's session; the daemon and other clients are
+untouched.
+
+## Rollback
+
+Serve mode is additive — the master/client and one-shot stdio modes are unchanged.
+
+```bash
+# client side: restore the previous command in your MCP config (a one-line revert)
+# server side:
+systemctl disable --now mcp-telegram
+```
+
+With the daemon stopped, the next client to start acquires the lock and becomes a master again
+(single-window behaviour).

--- a/packaging/mcp-telegram.env.example
+++ b/packaging/mcp-telegram.env.example
@@ -1,0 +1,10 @@
+# EnvironmentFile for the mcp-telegram shared daemon (serve mode).
+# Copy to /etc/mcp-telegram.env, fill in real values, and `chmod 600` it.
+# These credentials live only where the daemon runs; clients never need them.
+
+TELEGRAM_API_ID=
+TELEGRAM_API_HASH=
+TELEGRAM_SESSION_PATH=/root/.mcp-telegram/session
+
+# Optional: force the daemon explicitly even without the `serve` argument.
+# MCP_TELEGRAM_DAEMON=1

--- a/packaging/mcp-telegram.service
+++ b/packaging/mcp-telegram.service
@@ -1,0 +1,29 @@
+# systemd unit for the mcp-telegram shared daemon (serve mode).
+#
+# Deployment notes (paths are deployment-specific — adjust to your install):
+#   - ExecStart points at the built dist/cli.js with the `serve` subcommand.
+#   - Credentials live in the EnvironmentFile (see mcp-telegram.env.example), NOT here.
+#   - The daemon owns the single Telegram connection and listens on
+#     $(dirname TELEGRAM_SESSION_PATH)/daemon.sock; every other mcp-telegram process
+#     becomes a client and proxies tool calls over that socket.
+#
+# Install:
+#   cp packaging/mcp-telegram.service /etc/systemd/system/mcp-telegram.service
+#   cp packaging/mcp-telegram.env.example /etc/mcp-telegram.env   # then fill in credentials
+#   chmod 600 /etc/mcp-telegram.env
+#   systemctl daemon-reload && systemctl enable --now mcp-telegram
+
+[Unit]
+Description=mcp-telegram shared daemon (serve mode)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/mcp-telegram.env
+ExecStart=/usr/bin/node /opt/mcp-telegram/dist/cli.js serve
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/src/__tests__/lock.test.ts
+++ b/src/__tests__/lock.test.ts
@@ -112,4 +112,13 @@ describe("releaseSocket", () => {
     releaseSocket();
     assert.strictEqual(existsSync(socketPath()), false);
   });
+
+  it("removes socket when the lock PID is non-positive (never probes our own group)", () => {
+    // pid <= 0 must be ignored — process.kill(0, 0) would target our own process
+    // group and falsely report a live owner. Guard skips the kill and removes the socket.
+    writeFileSync(socketPath(), "");
+    writeFileSync(lockPath(), "0");
+    releaseSocket();
+    assert.strictEqual(existsSync(socketPath()), false);
+  });
 });

--- a/src/__tests__/lock.test.ts
+++ b/src/__tests__/lock.test.ts
@@ -82,7 +82,7 @@ describe("releaseLock", () => {
 });
 
 describe("releaseSocket", () => {
-  it("removes socket file if it exists", () => {
+  it("removes socket file if it exists (no lock → no owner)", () => {
     writeFileSync(socketPath(), "");
     releaseSocket();
     assert.strictEqual(existsSync(socketPath()), false);
@@ -90,5 +90,26 @@ describe("releaseSocket", () => {
 
   it("no socket file → does not throw", () => {
     assert.doesNotThrow(() => releaseSocket());
+  });
+
+  it("keeps socket when a live foreign process owns the lock", () => {
+    writeFileSync(socketPath(), "");
+    writeFileSync(lockPath(), String(process.ppid)); // ppid is always alive and != our pid
+    releaseSocket();
+    assert.strictEqual(existsSync(socketPath()), true, "must not delete a live foreign owner's socket");
+  });
+
+  it("removes socket when we own the lock", () => {
+    writeFileSync(socketPath(), "");
+    writeFileSync(lockPath(), String(process.pid));
+    releaseSocket();
+    assert.strictEqual(existsSync(socketPath()), false);
+  });
+
+  it("removes socket when the lock owner is a dead PID (stale)", () => {
+    writeFileSync(socketPath(), "");
+    writeFileSync(lockPath(), "999999999");
+    releaseSocket();
+    assert.strictEqual(existsSync(socketPath()), false);
   });
 });

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -41,7 +41,13 @@ function sendAndCollect(
         resolve({ messages, client });
       }
     });
-    client.on("error", reject);
+    client.on("error", (err) => {
+      // Clear the timer and tear down the socket before rejecting, so a late
+      // timeout can't fire a second rejection (and extra destroy) after an error.
+      clearTimeout(timer);
+      client.destroy();
+      reject(err);
+    });
   });
 }
 
@@ -57,8 +63,13 @@ describe("serve owner-core (startOwner)", () => {
     owner = await startOwner(stubTelegram, "test", { label: "serve-test" });
   });
 
-  after(() => {
-    owner?.srv.close();
+  after(async () => {
+    // Await the server actually closing — a UNIX socket server keeps the event
+    // loop alive and the socket path can linger, hanging the suite otherwise.
+    await new Promise<void>((resolve) => {
+      if (!owner?.srv) return resolve();
+      owner.srv.close(() => resolve());
+    });
     rmSync(sessionDir, { recursive: true, force: true });
     if (prevSessionPath === undefined) delete process.env.TELEGRAM_SESSION_PATH;
     else process.env.TELEGRAM_SESSION_PATH = prevSessionPath;
@@ -71,15 +82,11 @@ describe("serve owner-core (startOwner)", () => {
   it("serves two concurrent clients, routing each response to its own request id", async () => {
     const sock = socketPath();
     const [a, b] = await Promise.all([
-      sendAndCollect(
-        sock,
-        [{ type: "tool", id: "A1", tool: "telegram-status", args: {} }],
-        (m) => m.some((x) => x.type === "tool_response"),
+      sendAndCollect(sock, [{ type: "tool", id: "A1", tool: "telegram-status", args: {} }], (m) =>
+        m.some((x) => x.type === "tool_response"),
       ),
-      sendAndCollect(
-        sock,
-        [{ type: "tool", id: "B1", tool: "telegram-status", args: {} }],
-        (m) => m.some((x) => x.type === "tool_response"),
+      sendAndCollect(sock, [{ type: "tool", id: "B1", tool: "telegram-status", args: {} }], (m) =>
+        m.some((x) => x.type === "tool_response"),
       ),
     ]);
 
@@ -109,10 +116,8 @@ describe("serve owner-core (startOwner)", () => {
 
     assert.strictEqual(owner.srv.listening, true);
 
-    const b = await sendAndCollect(
-      sock,
-      [{ type: "tool", id: "D2", tool: "telegram-status", args: {} }],
-      (m) => m.some((x) => x.type === "tool_response"),
+    const b = await sendAndCollect(sock, [{ type: "tool", id: "D2", tool: "telegram-status", args: {} }], (m) =>
+      m.some((x) => x.type === "tool_response"),
     );
     const bResp = b.messages.find((m) => m.type === "tool_response");
     assert.strictEqual((bResp as { id: string }).id, "D2");

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert";
+import { mkdirSync, rmSync } from "node:fs";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { encodeMessage, type IpcMessage, parseMessages } from "../ipc-protocol.js";
+import { socketPath } from "../lock.js";
+import { type OwnerHandle, startOwner } from "../master.js";
+import { runServe } from "../serve.js";
+import type { TelegramService } from "../telegram-client.js";
+
+// A TelegramService whose every method is an async no-op — startOwner's auto-connect and any
+// tool handler resolve harmlessly without touching a real network.
+const stubTelegram = new Proxy({}, { get: () => async () => ({}) }) as unknown as TelegramService;
+
+function sendAndCollect(
+  sockPath: string,
+  toSend: IpcMessage[],
+  predicate: (msgs: IpcMessage[]) => boolean,
+  timeoutMs = 3000,
+): Promise<{ messages: IpcMessage[]; client: ReturnType<typeof connect> }> {
+  return new Promise((resolve, reject) => {
+    const client = connect(sockPath);
+    const messages: IpcMessage[] = [];
+    let buf = "";
+    const timer = setTimeout(() => {
+      client.destroy();
+      reject(new Error("collect timeout"));
+    }, timeoutMs);
+    client.on("connect", () => {
+      for (const m of toSend) client.write(encodeMessage(m));
+    });
+    client.on("data", (chunk) => {
+      buf += chunk.toString("utf-8");
+      const parsed = parseMessages(buf);
+      buf = parsed.remaining;
+      for (const m of parsed.messages) messages.push(m);
+      if (predicate(messages)) {
+        clearTimeout(timer);
+        resolve({ messages, client });
+      }
+    });
+    client.on("error", reject);
+  });
+}
+
+describe("serve owner-core (startOwner)", () => {
+  let owner: OwnerHandle;
+  let sessionDir: string;
+  const prevSessionPath = process.env.TELEGRAM_SESSION_PATH;
+
+  before(async () => {
+    sessionDir = join(tmpdir(), `serve-test-${process.pid}-${Date.now()}`);
+    mkdirSync(sessionDir, { recursive: true });
+    process.env.TELEGRAM_SESSION_PATH = join(sessionDir, "session");
+    owner = await startOwner(stubTelegram, "test", { label: "serve-test" });
+  });
+
+  after(() => {
+    owner?.srv.close();
+    rmSync(sessionDir, { recursive: true, force: true });
+    if (prevSessionPath === undefined) delete process.env.TELEGRAM_SESSION_PATH;
+    else process.env.TELEGRAM_SESSION_PATH = prevSessionPath;
+  });
+
+  it("listens on the IPC socket without any stdio transport", () => {
+    assert.strictEqual(owner.srv.listening, true);
+  });
+
+  it("serves two concurrent clients, routing each response to its own request id", async () => {
+    const sock = socketPath();
+    const [a, b] = await Promise.all([
+      sendAndCollect(
+        sock,
+        [{ type: "tool", id: "A1", tool: "telegram-status", args: {} }],
+        (m) => m.some((x) => x.type === "tool_response"),
+      ),
+      sendAndCollect(
+        sock,
+        [{ type: "tool", id: "B1", tool: "telegram-status", args: {} }],
+        (m) => m.some((x) => x.type === "tool_response"),
+      ),
+    ]);
+
+    const aResp = a.messages.find((m) => m.type === "tool_response");
+    const bResp = b.messages.find((m) => m.type === "tool_response");
+    assert.strictEqual((aResp as { id: string }).id, "A1", "client A gets only its own response");
+    assert.strictEqual((bResp as { id: string }).id, "B1", "client B gets only its own response");
+    assert.ok(!a.messages.some((m) => (m as { id?: string }).id === "B1"));
+    assert.ok(!b.messages.some((m) => (m as { id?: string }).id === "A1"));
+    a.client.destroy();
+    b.client.destroy();
+  });
+
+  it("survives a client disconnect — the daemon and other clients keep working", async () => {
+    const sock = socketPath();
+    await new Promise<void>((resolve) => {
+      const a = connect(sock);
+      a.on("connect", () => {
+        a.write(encodeMessage({ type: "tool", id: "D1", tool: "telegram-status", args: {} }));
+        setTimeout(() => {
+          a.destroy();
+          resolve();
+        }, 20);
+      });
+      a.on("error", () => resolve());
+    });
+
+    assert.strictEqual(owner.srv.listening, true);
+
+    const b = await sendAndCollect(
+      sock,
+      [{ type: "tool", id: "D2", tool: "telegram-status", args: {} }],
+      (m) => m.some((x) => x.type === "tool_response"),
+    );
+    const bResp = b.messages.find((m) => m.type === "tool_response");
+    assert.strictEqual((bResp as { id: string }).id, "D2");
+    b.client.destroy();
+  });
+
+  it("exports runServe as a function (daemon entrypoint)", () => {
+    assert.strictEqual(typeof runServe, "function");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,9 @@ const API_HASH = process.env.TELEGRAM_API_HASH;
 // runs without them — letting credentials stay only where the daemon runs.
 function requireCreds(): void {
   if (!API_ID || !API_HASH) {
-    console.error("[mcp-telegram] Missing TELEGRAM_API_ID and TELEGRAM_API_HASH (required to own the Telegram connection)");
+    console.error(
+      "[mcp-telegram] Missing TELEGRAM_API_ID and TELEGRAM_API_HASH (required to own the Telegram connection)",
+    );
     console.error("Get your credentials at https://my.telegram.org/apps (API development tools)");
     console.error("Set them in .env or export as environment variables");
     process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,24 +17,42 @@ const { version } = require("../package.json") as { version: string };
 const API_ID = Number(process.env.TELEGRAM_API_ID);
 const API_HASH = process.env.TELEGRAM_API_HASH;
 
-if (!API_ID || !API_HASH) {
-  console.error("[mcp-telegram] Missing TELEGRAM_API_ID and TELEGRAM_API_HASH");
-  console.error("Get your credentials at https://my.telegram.org/apps (API development tools)");
-  console.error("Set them in .env or export as environment variables");
-  process.exit(1);
+// Credentials are required only on the OWNER paths (serve/master) that open the real
+// Telegram connection. A client proxies every call over IPC and never connects, so it
+// runs without them — letting credentials stay only where the daemon runs.
+function requireCreds(): void {
+  if (!API_ID || !API_HASH) {
+    console.error("[mcp-telegram] Missing TELEGRAM_API_ID and TELEGRAM_API_HASH (required to own the Telegram connection)");
+    console.error("Get your credentials at https://my.telegram.org/apps (API development tools)");
+    console.error("Set them in .env or export as environment variables");
+    process.exit(1);
+  }
 }
 
 async function main() {
+  // Persistent daemon mode: `mcp-telegram serve` (or MCP_TELEGRAM_DAEMON=1). The daemon owns
+  // the connection with no stdio attached; every other process becomes a client.
+  if (process.argv[2] === "serve" || process.env.MCP_TELEGRAM_DAEMON === "1") {
+    requireCreds();
+    console.error("[mcp-telegram] Starting in serve (daemon) mode");
+    const { runServe } = await import("./serve.js");
+    await runServe(API_ID, API_HASH as string, version);
+    return;
+  }
+
   const isMaster = tryAcquireLock();
 
   if (isMaster) {
+    requireCreds();
     console.error("[mcp-telegram] Starting as master process");
     const { runMaster } = await import("./master.js");
     await runMaster(API_ID, API_HASH as string, version);
   } else {
-    console.error("[mcp-telegram] Starting as client process (master already running)");
+    // Client proxies all tool calls to the owner over IPC; the dummy TelegramService is
+    // never used for real calls, so API credentials are optional here.
+    console.error("[mcp-telegram] Starting as client process (owner already running)");
     const { runClient } = await import("./client.js");
-    await runClient(API_ID, API_HASH as string, version);
+    await runClient(API_ID || 0, API_HASH ?? "", version);
   }
 }
 

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -42,8 +42,11 @@ export function tryAcquireLock(): boolean {
           process.kill(pid, 0);
           // Process is alive — another master owns the lock
           return false;
-        } catch {
-          // ESRCH: process not found — stale lock, take over
+        } catch (err) {
+          // ESRCH: process not found — stale lock, take over.
+          // EPERM: process is alive but owned by another uid we can't signal —
+          // treat as a live owner and DON'T steal the lock.
+          if ((err as NodeJS.ErrnoException).code === "EPERM") return false;
           unlinkSync(lock);
         }
       }
@@ -87,12 +90,15 @@ export function releaseSocket(): void {
     const lock = lockPath();
     if (existsSync(lock)) {
       const pid = Number.parseInt(readFileSync(lock, "utf-8").trim(), 10);
-      if (!Number.isNaN(pid) && pid !== process.pid) {
+      // Ignore non-positive PIDs (e.g. 0) so kill() can't probe our own process group.
+      if (!Number.isNaN(pid) && pid > 0 && pid !== process.pid) {
         try {
           process.kill(pid, 0); // foreign owner still alive?
           return; // yes — leave its socket alone
-        } catch {
-          // ESRCH: stale owner — safe to remove
+        } catch (err) {
+          // ESRCH: stale owner — safe to remove. EPERM: owner is alive under a
+          // different uid (e.g. a systemd daemon) — leave its socket alone too.
+          if ((err as NodeJS.ErrnoException).code === "EPERM") return;
         }
       }
     }

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -79,6 +79,23 @@ export function releaseLock(): void {
 export function releaseSocket(): void {
   try {
     const sock = socketPath();
-    if (existsSync(sock)) unlinkSync(sock);
+    if (!existsSync(sock)) return;
+    // Ownership guard (mirrors releaseLock): never unlink a socket owned by a different,
+    // still-alive process. Otherwise any process that imports this module and exits (e.g. a
+    // one-shot run or a test on the same host) would delete a running daemon's socket file,
+    // leaving the daemon listening in memory but unreachable for new clients.
+    const lock = lockPath();
+    if (existsSync(lock)) {
+      const pid = Number.parseInt(readFileSync(lock, "utf-8").trim(), 10);
+      if (!Number.isNaN(pid) && pid !== process.pid) {
+        try {
+          process.kill(pid, 0); // foreign owner still alive?
+          return; // yes — leave its socket alone
+        } catch {
+          // ESRCH: stale owner — safe to remove
+        }
+      }
+    }
+    unlinkSync(sock);
   } catch {}
 }

--- a/src/master.ts
+++ b/src/master.ts
@@ -1,4 +1,4 @@
-import { createServer, type Socket } from "node:net";
+import { createServer, type Server, type Socket } from "node:net";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { GlobalLock } from "./global-lock.js";
@@ -27,8 +27,6 @@ function cleanup() {
 }
 
 process.on("exit", cleanup);
-process.on("SIGINT", () => process.exit(0));
-process.on("SIGTERM", () => process.exit(0));
 
 // Serializes tool calls with QR login — login holds the lock for up to minutes,
 // tool calls queue behind it. Prevents tool calls from running against a stale
@@ -148,18 +146,38 @@ async function handleLoginStart(socket: Socket, req: IpcLoginStart, telegram: Te
   }
 }
 
-export async function runMaster(apiId: number, apiHash: string, version: string): Promise<void> {
-  const telegram = new TelegramService(apiId, apiHash);
+export interface OwnerHandle {
+  server: McpServer;
+  srv: Server;
+  gracefulExit: () => Promise<void>;
+}
+
+/**
+ * Bootstrap the connection owner shared by master (stdio) and serve (daemon) modes:
+ * build the tool registry, listen on the IPC socket, install a graceful shutdown that
+ * disconnects Telegram, and auto-connect the single client. No stdio is attached here —
+ * the caller decides whether to also serve a stdio MCP session (master) or not (serve).
+ */
+export async function startOwner(
+  telegram: TelegramService,
+  version: string,
+  opts: { label?: string } = {},
+): Promise<OwnerHandle> {
+  const label = opts.label ?? "mcp-telegram";
 
   const server = new McpServer({ name: "mcp-telegram", version });
   registerTools(server, telegram);
   const mcpServer = server as unknown as McpServerInternal;
 
-  // Remove stale socket file from previous crash before attempting to listen (HIGH-2)
+  // Remove a stale socket file from a previous crash before attempting to listen.
   releaseSocket();
 
   const sock = socketPath();
-  const srv = createServer((socket) => handleClient(socket, mcpServer, telegram));
+  const srv = createServer((socket) => {
+    console.error(`[${label}] client connected`);
+    socket.on("close", () => console.error(`[${label}] client disconnected`));
+    handleClient(socket, mcpServer, telegram);
+  });
 
   await new Promise<void>((resolve, reject) => {
     srv.listen(sock, resolve);
@@ -171,29 +189,53 @@ export async function runMaster(apiId: number, apiHash: string, version: string)
     await chmod(sock, 0o600);
   } catch {}
 
-  console.error(`[mcp-telegram] Master mode — IPC socket ready: ${sock}`);
+  console.error(`[${label}] IPC socket ready: ${sock}`);
 
-  // Parent (Claude Code / MCP client) can close stdio without sending a signal.
-  // Without this, the process keeps running as an orphan with a live Telegram connection,
-  // blocking auth_key from being reused — causes AUTH_KEY_DUPLICATED on next start.
-  process.stdin.on("end", () => process.exit(0));
+  let shuttingDown = false;
+  const gracefulExit = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.error(`[${label}] Shutting down, disconnecting from Telegram...`);
+    try {
+      await telegram.disconnect();
+    } catch (err) {
+      console.error(`[${label}] Disconnect error:`, err);
+    }
+    process.exit(0);
+  };
 
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error("[mcp-telegram] MCP server running on stdio (master)");
+  process.on("SIGINT", gracefulExit);
+  process.on("SIGTERM", gracefulExit);
 
-  // Auto-connect with saved session — catch to avoid unhandled rejection (MEDIUM-2)
+  // Auto-connect with saved session — catch to avoid unhandled rejection.
   telegram
     .loadSession()
     .then(async () => {
       if (await telegram.connect()) {
         const me = await telegram.getMe();
-        console.error(`[mcp-telegram] Auto-connected as @${me.username}`);
+        console.error(`[${label}] connected as @${me.username}`);
       } else if (telegram.lastError) {
-        console.error(`[mcp-telegram] ${telegram.lastError}`);
+        console.error(`[${label}] ${telegram.lastError}`);
       }
     })
     .catch((err: unknown) => {
-      console.error("[mcp-telegram] Auto-connect failed:", err);
+      console.error(`[${label}] Auto-connect failed:`, err);
     });
+
+  return { server, srv, gracefulExit };
+}
+
+export async function runMaster(apiId: number, apiHash: string, version: string): Promise<void> {
+  const telegram = new TelegramService(apiId, apiHash);
+  const { server, gracefulExit } = await startOwner(telegram, version, { label: "mcp-telegram (master)" });
+
+  // Parent (Claude Code / MCP client) can close stdio without sending a signal.
+  // Without this, the process keeps running as an orphan with a live Telegram connection,
+  // blocking auth_key from being reused — causes AUTH_KEY_DUPLICATED on next start.
+  process.stdin.on("end", gracefulExit);
+
+  // Master also serves the launching window directly over stdio.
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("[mcp-telegram] MCP server running on stdio (master)");
 }

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,0 +1,26 @@
+import { tryAcquireLock } from "./lock.js";
+import { startOwner } from "./master.js";
+import { TelegramService } from "./telegram-client.js";
+
+/**
+ * Persistent daemon mode: own the single Telegram connection and serve many concurrent
+ * IPC clients, with no stdio and no stdin-exit, so closing any client never tears the
+ * connection down. Intended to run under a supervisor (systemd, Docker) with Restart=always.
+ */
+export async function runServe(apiId: number, apiHash: string, version: string): Promise<void> {
+  // The daemon must be the sole connection owner. If another owner already holds the lock,
+  // refuse rather than open a second client on the same session (AUTH_KEY_DUPLICATED).
+  if (!tryAcquireLock()) {
+    console.error("[serve] Another owner already holds the lock; refusing to start a second daemon.");
+    process.exit(1);
+  }
+
+  const telegram = new TelegramService(apiId, apiHash);
+
+  // Owner core: socket server + IPC dispatch + auto-connect + SIGINT/SIGTERM graceful shutdown.
+  // No StdioServerTransport and no process.stdin handler — the daemon's lifetime is independent
+  // of any client. The listening socket keeps the event loop alive until a termination signal.
+  await startOwner(telegram, version, { label: "serve" });
+
+  console.error("[serve] daemon ready — owning the Telegram connection, no stdio attached");
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `serve` (daemon) mode so a single Telegram account can serve **many MCP clients concurrently** — multiple Claude Code windows, parallel sub-agents, several IDEs — without `AUTH_KEY_DUPLICATED`.

Today every client process opens the same session and they evict one another. With `serve`, one persistent daemon owns the single connection and listens on the existing IPC socket; every other process auto-detects it via the PID lock and becomes a thin client that proxies tool calls. No stdio coupling, so closing any client never drops the shared connection. Fully backward compatible — the master/client and one-shot stdio paths are unchanged.

## Changes

- `src/serve.ts` — `runServe()`: claims the lock, owns the connection, no stdio, runs until SIGTERM.
- `src/master.ts` — extract a shared `startOwner()` core (socket server + IPC dispatch + auto-connect + graceful SIGINT/SIGTERM disconnect) reused by `runMaster` and `runServe`. `handleClient` semantics unchanged.
- `src/index.ts` — dispatch `serve` / `MCP_TELEGRAM_DAEMON=1`; credentials now required only on owner paths, so clients can run without `TELEGRAM_API_ID/HASH`.
- `src/lock.ts` — `releaseSocket()` now guards by lock ownership (mirrors `releaseLock`) so a non-owner process's exit cleanup can't delete a running daemon's socket.
- Tests: `serve.test.ts` (two concurrent clients route by id, disconnect isolation), `lock.test.ts` (releaseSocket ownership).
- Docs: `docs/guides/shared-daemon.md` + `packaging/` (systemd unit + EnvironmentFile) + a README section.

## Test plan

- `npm test` — full suite green (512 tests) on Linux.
- `npm run build` and `tsc --noEmit` clean.
- Verified live: a daemon serving multiple concurrent clients on one account with no `AUTH_KEY_DUPLICATED`; a credential-less client connects to the daemon; closing one client does not affect others.

Notes: the UNIX-socket tests require Linux/macOS. Opt-in only — default behaviour is unchanged.