### PR TITLE
docs: generate changelog pages from CHANGELOG.md + refresh README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,13 @@ jobs:
       - run: npx biome check src/
       - run: npx tsc --noEmit
       - run: npm run build
+      # Fail the PR if the committed changelog docs drift from CHANGELOG.md.
+      # Run `npm run gen:changelog` and commit to fix. Checked before the build
+      # below so a stale changelog is caught even if the build would pass.
+      - run: npm run gen:changelog:check
       # Build the docs site so a dead link / broken VitePress fails the PR,
       # not main. Deploy Docs (docs.yml) only runs on push to main, so without
       # this a bad doc link is invisible until after merge (PR #49 hit this).
+      # `vitepress build docs` directly (not docs:build) so predocs:build does
+      # NOT regenerate and mask a stale commit — gen:changelog:check owns that.
       - run: npx vitepress build docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'CHANGELOG.md'
+      - 'scripts/gen-changelog-docs.ts'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/docs.yml'
@@ -31,7 +33,9 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: npx vitepress build docs
+      # docs:build runs predocs:build (gen:changelog) first, so the deployed
+      # site always reflects CHANGELOG.md even if the committed pages lag.
+      - run: npm run docs:build
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/@overpod/mcp-telegram)](https://www.npmjs.com/package/@overpod/mcp-telegram)
 [![Node.js](https://img.shields.io/badge/Node.js-18%2B-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.27-green.svg)](https://modelcontextprotocol.io/)
+[![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.29-green.svg)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![mcp-telegram MCP server](https://glama.ai/mcp/servers/overpod/mcp-telegram/badges/score.svg)](https://glama.ai/mcp/servers/overpod/mcp-telegram)
 
@@ -18,13 +18,15 @@ An MCP (Model Context Protocol) server that connects AI assistants like Claude t
 
 ## Features
 
-- **Comprehensive tool coverage** -- the most full-featured Telegram MCP server available (80+ tools)
+- **Comprehensive tool coverage** -- the most full-featured Telegram MCP server available
 - **MTProto protocol** -- direct Telegram API access, not the limited Bot API
 - **Userbot** -- operates as your personal account, not a bot
 - **Full-featured** -- messaging, reactions, polls, scheduled messages, stickers, media, contacts, and more
 - **Forum Topics** -- list topics, read per-topic messages, send to specific topics, per-topic unread counts
 - **Stickers** -- search sticker sets, browse installed/recent stickers, send stickers to any chat
 - **Account & profile management** -- update profile, set emoji status, birthday, personal channel, profile photo, manage privacy settings, sessions, auto-delete timers
+- **Chat folders** -- create, edit, delete and reorder folders, toggle folder tags, read suggested folders (v1.33.0)
+- **Global privacy** -- read and set account-wide privacy settings (v1.33.0)
 - **Global search** -- search messages across all chats at once
 - **Real-time polling** -- fetch updates via stateless cursors; agent owns `{pts, qts, date}` state
 - **Inline bots & buttons** -- query inline bots, send results, press callback buttons
@@ -34,6 +36,8 @@ An MCP (Model Context Protocol) server that connects AI assistants like Claude t
 - **Admin controls** -- toggle channel signatures, anti-spam, forum mode, prehistory; approve join requests
 - **Stats** -- channel and supergroup analytics (GetBroadcastStats / GetMegagroupStats)
 - **Boosts & Business** -- boost status, boosters list, Telegram Business chat links CRUD, work hours, location, greeting/away/intro messages
+- **Star gifts** -- browse available and saved gifts, save/convert gifts, manage Stars balance and subscriptions (opt-in via `MCP_TELEGRAM_ENABLE_STARS=1`, v1.34.0)
+- **Shared daemon** -- one background process serves multiple MCP clients over a single Telegram session; see the [shared-daemon guide](https://mcp-telegram.github.io/mcp-telegram/guides/shared-daemon) (v1.38.0)
 - **QR code login** -- authenticate by scanning a QR code in the Telegram app
 - **Session persistence** -- login once, stay connected across restarts
 - **Human-readable output** -- sender names are resolved, not just numeric IDs
@@ -363,6 +367,8 @@ All tools are auto-discoverable via MCP — your AI client will see the full lis
 | **Rich Media Sending** | `telegram-send-voice`, `telegram-send-video-note` (round video), `telegram-send-location` (static or live), `telegram-send-venue`, `telegram-send-contact`, `telegram-send-dice` (🎲🎯🎰🏀⚽🎳), `telegram-send-album` (2–10 grouped photos/videos) |
 | **Groups** | `telegram-create-group`, `telegram-edit-group`, `telegram-invite-to-group`, `telegram-join-chat`, `telegram-leave-group`, `telegram-kick-user`, `telegram-ban-user`, `telegram-unban-user`, `telegram-set-admin`, `telegram-remove-admin`, `telegram-get-my-role`, `telegram-set-chat-permissions`, `telegram-set-slow-mode`, `telegram-get-admin-log` |
 | **Chat Info** | `telegram-get-chat-info`, `telegram-get-chat-members`, `telegram-get-chat-folders` |
+| **Folders (v1.33.0)** | `telegram-create-folder`, `telegram-edit-folder`, `telegram-delete-folder`, `telegram-reorder-folders`, `telegram-get-suggested-folders`, `telegram-toggle-folder-tags` |
+| **Global Privacy (v1.33.0)** | `telegram-get-global-privacy-settings`, `telegram-set-global-privacy-settings` |
 | **Invite Links** | `telegram-create-invite-link`, `telegram-get-invite-links`, `telegram-revoke-invite-link` |
 | **Contacts** | `telegram-get-contacts`, `telegram-add-contact`, `telegram-get-contact-requests` |
 | **Moderation** | `telegram-block-user`, `telegram-unblock-user`, `telegram-report-spam` |
@@ -381,7 +387,7 @@ All tools are auto-discoverable via MCP — your AI client will see the full lis
 | **Read Receipts (v1.30.0)** | `telegram-get-message-read-participants`, `telegram-get-outbox-read-date` |
 | **Boosts** | `telegram-get-my-boosts`, `telegram-get-boosts-status`, `telegram-get-boosts-list` |
 | **Business (v1.32.0)** | `telegram-get-business-chat-links`, `telegram-create-business-chat-link`, `telegram-edit-business-chat-link`, `telegram-delete-business-chat-link`, `telegram-resolve-business-chat-link`, `telegram-set-business-hours`, `telegram-set-business-location`, `telegram-set-business-greeting`, `telegram-set-business-away`, `telegram-set-business-intro` |
-| **Opt-in (env-gated)** | `telegram-get-group-call`, `telegram-get-group-call-participants` (requires `MCP_TELEGRAM_ENABLE_GROUP_CALLS=1`), `telegram-get-stars-status`, `telegram-get-stars-transactions` (requires `MCP_TELEGRAM_ENABLE_STARS=1`), `telegram-get-quick-replies`, `telegram-get-quick-reply-messages` (requires `MCP_TELEGRAM_ENABLE_QUICK_REPLIES=1`) |
+| **Opt-in (env-gated)** | `telegram-get-group-call`, `telegram-get-group-call-participants` (requires `MCP_TELEGRAM_ENABLE_GROUP_CALLS=1`); Stars & gifts `telegram-get-stars-status`, `telegram-get-stars-transactions`, `telegram-get-stars-topup-options`, `telegram-get-stars-subscriptions`, `telegram-change-stars-subscription`, `telegram-get-available-star-gifts`, `telegram-get-saved-star-gifts`, `telegram-save-star-gift`, `telegram-convert-star-gift` (requires `MCP_TELEGRAM_ENABLE_STARS=1`); `telegram-get-quick-replies`, `telegram-get-quick-reply-messages` (requires `MCP_TELEGRAM_ENABLE_QUICK_REPLIES=1`) |
 
 > **Tip**: Ask your AI assistant *"What Telegram tools are available?"* to get the full list with parameters and descriptions.
 
@@ -392,7 +398,7 @@ Some tools are disabled by default and must be opted in via environment variable
 | Variable | Value | Tools enabled |
 |----------|-------|---------------|
 | `MCP_TELEGRAM_ENABLE_GROUP_CALLS` | `1` | `telegram-get-group-call`, `telegram-get-group-call-participants` |
-| `MCP_TELEGRAM_ENABLE_STARS` | `1` | `telegram-get-stars-status`, `telegram-get-stars-transactions` |
+| `MCP_TELEGRAM_ENABLE_STARS` | `1` | Stars balance & transactions, top-up options, subscriptions, and Star Gifts (browse / save / convert) |
 | `MCP_TELEGRAM_ENABLE_QUICK_REPLIES` | `1` | `telegram-get-quick-replies`, `telegram-get-quick-reply-messages` |
 
 Add these to your `.env` file or MCP client config to enable them.

--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,7 @@
   },
   "overrides": [
     {
-      "includes": ["src/index.ts", "src/qr-login-cli.ts", "src/cli.ts"],
+      "includes": ["src/index.ts", "src/qr-login-cli.ts", "src/cli.ts", "scripts/**"],
       "linter": {
         "rules": {
           "suspicious": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,242 +1,653 @@
 # Changelog
 
-<VersionBadge version="1.26.0" /> Current version
+<VersionBadge version="1.38.1" /> Current version
 
-All notable changes to MCP Telegram. For full diff between versions, see [GitHub Releases](https://github.com/mcp-telegram/mcp-telegram/releases).
+All notable changes to MCP Telegram. For the full diff between versions, see [GitHub Releases](https://github.com/mcp-telegram/mcp-telegram/releases).
+
+<!-- Generated from CHANGELOG.md by scripts/gen-changelog-docs.ts. Do not edit by hand. -->
+
+## 1.38.1 — 2026-06-10 <Badge type="tip" text="latest" /> {#v1-38-1}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.38.0 — 2026-06-10 {#v1-38-0}
+
+### Added
+
+- shared daemon (serve mode) for concurrent MCP clients (#49)
+
+## 1.37.1 — 2026-06-06 {#v1-37-1}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.37.0 — 2026-06-04 {#v1-37-0}
+
+### Added
+
+- `TELEGRAM_USE_WSS` env-var. When set to `true`, gramJS uses port `443` instead of the default `80` for the MTProto TCPFull transport. This unblocks deployments on VPS/hosting IP ranges where outbound port `80` to Telegram DC IP blocks is dropped (anti-abuse policy on some shared-VPS providers), which otherwise hangs the client forever in `Connecting to ...:80/TCPFull...`. Default is `false`, so existing setups are unaffected. Contributed by Ivan Ponomarev (@Baho73).
+- When `TELEGRAM_USE_WSS=true` is combined with `TELEGRAM_PROXY_*` (which gramJS cannot do — SSL transport over a proxy is unsupported), the conflict is now detected early: a clear warning is logged and `useWSS` is ignored, letting the proxy take precedence, instead of crashing deep inside `connect()`.
+
+## 1.36.5 — 2026-06-01 {#v1-36-5}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.4 — 2026-05-28 {#v1-36-4}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.3 — 2026-05-10 {#v1-36-3}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.2 — 2026-05-10 {#v1-36-2}
+
+### Changed
+
+  - `hono` 4.12.9 → 4.12.18 (CSS injection in JSX SSR, JWT NumericDate, Cache `Vary`, etc.)
+  - `fast-uri` 3.1.0 → 3.1.2 (host confusion + path traversal)
+  - `ip-address` 10.1.0 → 10.2.0 (Address6 HTML XSS)
+  - `@hono/node-server` 1.19.11 → 1.19.14 (middleware bypass via repeated slashes)
+  - `express-rate-limit` 8.3.1 → 8.5.1
+- 3 remaining moderate advisories in `vitepress → vite → esbuild` are dev-only (docs site) with no upstream fix available.
+
+## 1.36.1 — 2026-05-04 {#v1-36-1}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.0 — 2026-04-28 {#v1-36-0}
+
+### Added
+
+- `destructiveHint: true` → `destructive`
+- `readOnlyHint: true` → `read-only`
+- otherwise → `write`
+
+### Notes
+
+- New public API surface; no breaking changes to existing exports.
+- `src/manifest.ts` and 13 new tests added; total test count: 505.
+- Build now sets executable bits on all `dist/*-cli.js` outputs (was npm-install-time only for `bin` entries).
+
+## 1.35.0 — 2026-04-25 {#v1-35-0}
+
+### Changed
+
+- `event` — event class (string literal)
+- `context` — caller-supplied operation name (never user input / PII)
+- `attempt` / `maxRetries` — retry counters
+- `seconds` (flood_wait only) or `delayMs` (network/temporary)
+- `error` (network/temporary only) — the upstream Telegram error message
+
+## 1.34.0 — 2026-04-24 {#v1-34-0}
+
+### Added
+
+- **telegram-get-available-star-gifts** — List all available Star Gift catalog items: gift ID, cost in Stars, conversion value, limited-edition availability, and upgrade cost
+- **telegram-get-saved-star-gifts** — List Star Gifts received by a user/chat. Supports pagination (`offset`/`nextOffset`), filter flags (`excludeUnsaved`, `excludeSaved`, `excludeUnlimited`, `excludeLimited`, `excludeUnique`), and `sortByValue`. Returns kind (regular/unique), from-peer, date, and upgrade eligibility
+- **telegram-save-star-gift** — Show or hide a received gift on your profile. For personal gifts pass `msgId`; for chat/channel gifts pass `chatId` + `savedId`. Set `unsave=true` to hide, omit to show
+- **telegram-convert-star-gift** — Convert a received gift into Stars (non-reversible, removes gift from profile). Same addressing as save: `msgId` for personal, `chatId`+`savedId` for chat gifts
+- **telegram-get-stars-topup-options** — List available Stars top-up tiers with star count, currency, price amount (smallest currency units), and extended/standard tier flag
+- **telegram-get-stars-subscriptions** — List active Stars subscriptions for a peer (`me` for self). Returns subscription ID, peer, until date, billing period (seconds), price in Stars, canceled status, and title. Pagination via `offset`
+- **telegram-change-stars-subscription** — Cancel or restore a Stars subscription by ID. `canceled=true` to cancel before next renewal, `canceled=false` to restore
+
+## 1.33.0 — 2026-04-24 {#v1-33-0}
+
+### Added
+
+- **telegram-create-folder** — Create a new chat folder. Accepts `title` (max 12 chars), optional `emoticon`, type flags (`contacts`, `nonContacts`, `groups`, `broadcasts`, `bots`), filter flags (`excludeMuted`, `excludeRead`, `excludeArchived`), and peer lists (`includePeers`, `excludePeers`, `pinnedPeers` max 5). Auto-assigns the next available folder ID ≥ 2. Returns the new ID
+- **telegram-edit-folder** — Edit an existing folder by `id`. Only pass fields to change — omitted fields preserve current values (fetches current state first via `messages.GetDialogFilters`)
+- **telegram-delete-folder** — Delete a chat folder by ID. Chats remain in All Chats. System folders (0 = All Chats, 1 = Archive) cannot be deleted. Uses `messages.UpdateDialogFilter` without a filter argument
+- **telegram-reorder-folders** — Set the display order of folders by passing an ordered array of folder IDs. Uses `messages.UpdateDialogFiltersOrder`
+- **telegram-get-suggested-folders** — Fetch Telegram's server-side folder suggestions based on your chat list (e.g. "Unread", "Work", "Personal"). Skips `DialogFilterDefault` entries that lack a title
+- **telegram-toggle-folder-tags** — Enable or disable folder tag labels on messages in chat lists. Requires Telegram Premium. Uses `messages.ToggleDialogFilterTags`
+- **telegram-get-global-privacy-settings** — Read all five global privacy flags: `archiveAndMuteNewNoncontactPeers`, `keepArchivedUnmuted`, `keepArchivedFolders`, `hideReadMarks`, `newNoncontactPeersRequirePremium`. Returns JSON
+- **telegram-set-global-privacy-settings** — Update any subset of global privacy flags. Fetches current settings first and merges only the fields you pass. `hideReadMarks` and `newNoncontactPeersRequirePremium` require Telegram Premium
+
+## 1.32.0 — 2026-04-24 {#v1-32-0}
+
+### Added
+
+- **telegram-set-emoji-status** — Set custom animated emoji status next to your name (Telegram Premium). Pass `documentId` or `collectibleId`; omit both to clear. Supports optional expiry via `untilUnix`
+- **telegram-list-emoji-statuses** — List available emoji statuses: `default`, `recent`, `channel_default`, or `collectible` (Premium). Returns `documentId`, `until`, collectible `title`/`slug`
+- **telegram-clear-recent-emoji-statuses** — Remove all entries from the "recent" emoji status picker section
+- **telegram-set-profile-color** — Set your name or profile background color. `forProfile=false` = chat list name color; `forProfile=true` = profile page background (Premium). Accepts color index 0-6 (free) or 7-20 (Premium) plus optional background pattern emoji
+- **telegram-set-birthday** — Add/update birthday on profile (`day` + `month` required, `year` optional to hide age). Pass `clear=true` to remove
+- **telegram-set-personal-channel** — Feature a channel on your profile as "Personal Channel". Pass `channelId` or `clear=true` to remove
+- **telegram-set-profile-photo** — Upload static (JPEG/PNG) or animated (MP4, square, ≤10s) avatar. Optional `fallback=true` sets it as the privacy fallback shown when your main photo is hidden
+- **telegram-delete-profile-photo** — Delete one or more profile photos by photo ID (stringified long). Fetches your photo history internally to build the required `InputPhoto`; reports which IDs were not found
+- **telegram-get-business-chat-links** — Moved from `account.ts` to new `business.ts` module. Behavior unchanged (read-only list of Business chat links)
+- **telegram-create-business-chat-link** — Create a `t.me/m/...` deep-link pre-filled with a message. Supports `parseMode` (md/html), optional admin `title`. Returns JSON with `link`, `slug`, `message`, `views`
+- **telegram-edit-business-chat-link** — Update an existing Business chat link by slug. Same options as create
+- **telegram-delete-business-chat-link** — Delete a Business chat link by slug
+- **telegram-resolve-business-chat-link** — Resolve a slug to see who it opens a chat with and the pre-filled message. Returns `peerId`, `peerType`, `message`, `entityCount`
+- **telegram-set-business-hours** — Configure weekly work hours (Telegram Business required). Input: `timezone` (IANA string) + `schedule` array of `{day, openFrom, openTo}` in HH:MM. Internally converts to minute-of-week (0–10079). `clear=true` disables
+- **telegram-set-business-location** — Set street address ± geo coordinates for Business profile. `clear=true` removes
+- **telegram-set-business-greeting** — Auto-reply for new conversations using a Quick Reply shortcut as template. `audience` enum (all_new / contacts_only / non_contacts / existing_only), `noActivityDays`, optional include/excludeUsers. `clear=true` disables
+- **telegram-set-business-away** — Auto-reply when offline or outside hours. `schedule` enum (always / outside_hours / custom). `custom` requires `customFrom`/`customTo` Unix timestamps. `offlineOnly` flag. Same audience model as greeting. `clear=true` disables
+- **telegram-set-business-intro** — Intro card shown to new users: `title` (≤32) + `description` (≤70) + optional sticker (requires `stickerId` + `stickerAccessHash` + `stickerFileReference` all together). `clear=true` removes
+
+### Notes
+
+- All Premium-gated tools (`telegram-set-emoji-status`, `telegram-set-profile-color` with index ≥ 7 or `backgroundEmojiId`) throw `PREMIUM_ACCOUNT_REQUIRED` from Telegram on non-Premium accounts — the error is propagated as-is
+- All Business-gated tools throw `BUSINESS_PEER_INVALID` or similar when the account lacks Telegram Business subscription
+- `telegram-get-business-chat-links` moved to `src/tools/business.ts` — tool name and behavior unchanged
+- `telegram-set-profile-photo`: uploads via GramJS `uploadFile` (4 workers). Video must be square MP4, ≤10s; server enforces its own size limits
+- `telegram-delete-profile-photo`: calls `photos.GetUserPhotos` first (up to 100) to resolve `accessHash` + `fileReference` from the photo ID; IDs not in your history are returned in `missing` array
+
+## 1.31.0 — 2026-04-24 {#v1-31-0}
+
+### Added
+
+- **telegram-vote-poll** — Vote in a poll by option index (single/multi-choice). Empty array retracts vote.
+- **telegram-get-poll-results** — Get aggregated poll results: vote counts, percentages, quiz answer status
+- **telegram-get-poll-voters** — List users who voted for specific poll options (public polls only, paginated)
+- **telegram-close-poll** — Permanently close a poll (irreversible; prevents further voting)
+- **telegram-transcribe-audio** — Start server-side transcription of a voice/video note (Telegram Premium)
+- **telegram-get-transcription** — Poll for updated transcription status (idempotent re-call)
+- **telegram-rate-transcription** — Rate transcription quality (good/poor) to improve speech-to-text
+- **telegram-get-fact-check** — Get fact-check annotations on channel messages (batch up to 100)
+- **telegram-edit-fact-check** — Add/update fact-check annotation (requires fact-checker privileges)
+- **telegram-delete-fact-check** — Remove fact-check annotation (requires fact-checker privileges)
+- **telegram-send-paid-reaction** — Send paid reaction (★ Stars) on a channel post with optional privacy
+- **telegram-toggle-paid-reaction-privacy** — Change leaderboard visibility of your paid reaction
+- **telegram-get-paid-reaction-privacy** — Get your current default paid reaction privacy setting
+
+### Notes
+
+- `telegram-close-poll`: One-way operation — closed polls cannot be reopened
+- `telegram-transcribe-audio`: Premium feature. Non-Premium accounts have limited free trials; `trialRemainsNum` shows count
+- `telegram-get-transcription`: Idempotent — returns same transcriptionId with updated text once processing completes
+- `telegram-edit-fact-check` / `telegram-delete-fact-check`: Require fact-checker privileges; regular users get permission errors
+- `telegram-send-paid-reaction`: Stars are debited from your Telegram balance; `count` range 1-2500
+- `telegram-toggle-paid-reaction-privacy`: Per-message toggle (Layer 198 API)
+
+### New helpers (exported from `telegram-client`)
+
+- `summarizePoll(poll, results?)` — summarize a GramJS Poll+PollResults into a compact typed object
+- `extractPollMediaFromUpdates(updates)` — extract poll + results from any Updates envelope
+- `extractPeerId(peer)` — convert TypePeer to string ID
+
+### Testing
+
+- 29 new mock-only tests (cumulative: 447 total)
+
+## 1.30.0 — 2026-04-24 {#v1-30-0}
+
+### Added
+
+- **telegram-send-story** — Publish a photo or video story to your profile or a channel with privacy controls (everyone/contacts/close_friends/selected), period (6-48h), pinning, and no-forward flag. Accepts absolute file path, auto-detects photo/video from extension (jpg/jpeg/png/webp/heic/heif → photo; everything else → video). Caption supports md/html parse mode.
+- **telegram-edit-story** — Edit an existing story: replace media, update caption (empty string clears it), or change privacy rules. At least one field (filePath, caption, or privacy) must be provided.
+- **telegram-delete-stories** — Delete one or more stories (irreversible; requires `confirm: true`; up to 100 IDs per call). Returns the actually-deleted IDs from Telegram (partial success possible).
+- **telegram-react-to-story** — React to a story with an emoji, or remove the reaction by passing empty string `""`.
+- **telegram-export-story-link** — Get a shareable `t.me/…` URL for a public story.
+- **telegram-read-stories** — Mark stories as seen up to a given story ID (maxId, inclusive). Returns count of newly-seen stories.
+- **telegram-toggle-story-pinned** — Pin/unpin stories in profile highlights (Telegram allows up to 3 pinned stories). Returns affected story IDs.
+- **telegram-toggle-story-pinned-to-top** — Pin stories to the very top of the pinned row; pass `[]` to clear all top-pinned stories.
+- **telegram-activate-stealth-mode** — Hide your story views retroactively (`past: true`) and/or for the next 25 minutes (`future: true`). At least one of past/future must be true. Requires Telegram Premium — non-Premium accounts receive PREMIUM_ACCOUNT_REQUIRED.
+- **telegram-get-stories-archive** — Fetch auto-archived (expired) stories from a peer's archive, paginated via `offsetId` + `limit` (1–100, default 50).
+- **telegram-report-story** — Report a story via Telegram's multi-step option flow. First call with `option: ""` starts the flow; subsequent calls pass the base64 option bytes from the previous response's `options[n].option` field.
+- **telegram-get-discussion-message** — For a channel post with comments enabled, returns the linked discussion-group info: `discussionGroupId`, `discussionMsgId`, `unreadCount`, `readInboxMaxId`, `readOutboxMaxId`, `topMessage`. Use `discussionGroupId` + `discussionMsgId` with `telegram-send-message` (replyTo=discussionMsgId) to post a comment.
+- **telegram-get-groups-for-discussion** — List groups eligible to link as discussion group to a channel you admin (channels.GetGroupsForDiscussion). No parameters required.
+- **telegram-get-message-read-participants** — List who has read a message in a small group (≤100 members, ≤7 days old). Returns `readers` array with `userId` and `readAt` (ISO timestamp). Returns CHAT_TOO_BIG error for large groups or channels.
+- **telegram-get-outbox-read-date** — Get when your recipient read your outgoing private message. Returns `"Read at <ISO date>"` or `"Not read yet"` (maps NOT_READ_YET error to null). Propagates YOUR_PRIVACY_RESTRICTED / USER_PRIVACY_RESTRICTED as errors.
+
+### New helpers in `telegram-helpers.ts`
+
+- `StoryPrivacy` type and `buildStoryPrivacyRules()` — builds GramJS `TypeInputPrivacyRule[]` from privacy enum + allow/disallow user ID lists
+- `detectMediaType()` — infers photo/video from file extension (safe default: video)
+- `extractStoryIdFromUpdates()` — extracts story ID from SendStory Updates envelope (prefers UpdateStoryID, falls back to UpdateStory)
+- `summarizeDiscussionMessage()`, `DiscussionMessageSummary` type
+- `summarizeGroupsForDiscussion()`, `GroupsForDiscussionSummary` type
+- `summarizeReadParticipants()`, `ReadParticipantsSummary` type
+- `summarizeReportResult()`, `ReportResultSummary` type (discriminated union: reported / chooseOption / addComment)
+
+### Notes
+
+- `telegram-activate-stealth-mode` requires Telegram Premium — non-Premium accounts receive PREMIUM_ACCOUNT_REQUIRED
+- `telegram-get-message-read-participants` only works for groups ≤100 members and messages ≤7 days old
+- `telegram-delete-stories` requires `confirm: true` (irreversible)
+- `telegram-send-story`: MediaAreas (venue/reaction/URL tags on the story frame) are not supported in this version
+- `telegram-report-story`: Multi-step flow — first call with `option: ""` starts the flow; subsequent calls pass the base64 option bytes from the previous response
+
+### Testing
+
+- 45 new mock-only tests in `src/__tests__/stories-v2.test.ts` (cumulative: 418 total)
+
+## 1.29.0 — 2026-04-23 {#v1-29-0}
+
+### Added
+
+- **Phase 5 Block A — Rich media sending (7 new tools)** — functional parity with Telegram UI for content types that could not be sent before.
+  - `telegram-send-voice` — send a voice note (OGG/Opus preferred) with optional caption, parseMode, reply/topic. Shows as a waveform UI in the chat.
+  - `telegram-send-video-note` — send a round-shaped video message (MP4, square recommended; duration ≤60s enforced client-side, length ≤640px).
+  - `telegram-send-location` — send a geographic location; single tool handles both static pins and live-updating locations (`livePeriod` 60–86400 seconds; optional `heading` 1–360°, `proximityRadius` meters).
+  - `telegram-send-venue` — send a venue card (title, address, lat/long + optional provider-specific metadata).
+  - `telegram-send-contact` — send a contact card (phone number in E.164-like format `^\+?\d{6,15}$`, first name, optional last name and vCard).
+  - `telegram-send-dice` — send an animated dice/game emoji (🎲 🎯 🎰 🏀 ⚽ 🎳) and receive the server-rolled value in the response.
+  - `telegram-send-album` — send 2–10 grouped photos/videos as a single album message with per-item or album-level caption.
+- **Block B — enhancements to existing `telegram-send-message`:**
+  - `quoteText` — attach a verbatim quote from the replied-to message (requires `replyTo`). Uses raw `messages.SendMessage` + `InputReplyToMessage.quoteText` under the hood.
+  - `effect` — Premium message effect ID (numeric string) attached to the outgoing message.
+- **Defence-in-depth for file-path inputs (`isSafeAbsolutePath`)** — all new `filePath` parameters reject:
+  - URL schemes (`http:`, `https:`, `file:`, `ftp:`, `data:`, `javascript:`, `ws:`, `wss:`) — no SSRF via GramJS URL-fetching.
+  - UNC / SMB shares (`\\server\share`, `//server/share`) — no NTLM-relay from Windows hosts.
+  - Path traversal (`..` segments inside an absolute path) — no escape out of the intended directory.
+  - POSIX pseudo-filesystems (`/proc`, `/sys`, `/dev`, `/run`) — prevents AI prompt-injection from reading `/proc/self/environ` and leaking env vars / session paths to Telegram.
+  - Embedded NUL byte and bare `/` — rejected explicitly.
+- **UTF-16 surrogate sanitation on input** — all free-text parameters (message `text`, captions, venue title/address/provider/venueId/venueType, contact name/vCard, quoteText) now strip unpaired surrogates before reaching GramJS's TL encoder. Complements the existing v1.11.1 output-side fix.
+- **Shared helpers in `telegram-helpers.ts`:**
+  - `buildReplyTo(replyTo?, topicId?)` — construct `InputReplyToMessage` (supports topic root where `replyToMsgId === topicId`).
+  - `generateRandomBigInt()` — cryptographically-random 64-bit `long` for TL `randomId`.
+  - `extractMessageId(result)` — unified parser across `Api.Updates`, `UpdatesCombined`, `Api.Message`, `UpdateShortSentMessage`, `UpdateNewMessage`, `UpdateNewChannelMessage`.
+  - `extractDiceResult(result)` — dice-specific extractor returning `{id, value?}` from `MessageMediaDice`.
+
+### Changed
+
+- `telegram-send-contact`: `phone` field now validated against `^\+?\d{6,15}$` (E.164-like) to reject malformed/hallucinated numbers.
+- `telegram-send-venue`: `provider` relaxed from a 2-value enum to a free string (≤32 chars) to match TL `venueProvider: string`.
+- `TelegramService.sendMessage()`: gained an optional 6th `extra: { quoteText?, effect? }` parameter. When set, falls back to raw `messages.SendMessage` (high-level `client.sendMessage` does not support these fields). Backward-compatible — existing callers see no change.
+
+### Security
+
+- `quoteText` without `replyTo` now raises a clear error instead of silently dropping the quote.
+- `effect` ID regex tightened to `^\d{1,19}$` (Int64-safe range).
+
+### Testing
+
+- 371 unit tests (was 322 in v1.28.1, +49). All tests mock-only (no live Telegram connection).
+- New coverage: all 8 new/changed service methods, helper edge cases (channel path, combined updates, direct Api.Message, UpdateShortSentMessage), SSRF guard (POSIX/Windows accept + URL/UNC/traversal/pseudo-fs reject), raw-path `sendMessage` with `quoteText` / `effect`.
+
+### Notes & known limitations
+
+- **`telegram-send-video-note` caption omitted** — Telegram UI does not render captions under round video notes; including it here would silently drop.
+- **`telegram-send-contact.userId` field dropped** — GramJS 2.26.22 `InputMediaContact` TL schema (Layer 198) has no `userId` slot. The card is standalone; recipients see the number and name, not a link to a Telegram user. Will return once GramJS advances.
+- **TTL / self-destruct media** — deferred. Requires raw `InputMediaUploadedPhoto({ttlSeconds})` path which bypasses the high-level `sendFile`; will ship in a follow-up.
+- **`telegram-send-voice.duration` removed vs. initial design** — GramJS auto-detects duration from the audio file; letting the AI override it caused the Telegram UI to display wrong playback times.
+- **Album mixed photo+video** — GramJS accepts mixed arrays via extension-based detection, but this is not covered by tests; recommend uniform media type per album until a live-test checkpoint confirms.
+- **Album flood control** — a 10-item album fans out 10 `messages.UploadMedia` calls inside one rate-limit slot; under heavy contention the later items may still hit `FLOOD_WAIT`. Rate limiter retries apply.
 
 ## 1.26.0 — 2026-04-20 {#v1-26-0}
 
-### Added (29 new tools)
+### Added
 
-**Phase 2 — Admin Toggles, Customization, Stats (8)**
-- `telegram-toggle-channel-signatures`, `telegram-toggle-anti-spam`, `telegram-toggle-forum-mode` (destructive on disable; requires `confirm: true`)
-- `telegram-toggle-prehistory-hidden`, `telegram-set-chat-reactions`
-- `telegram-approve-join-request`
-- `telegram-get-broadcast-stats`, `telegram-get-megagroup-stats`
-
-**Phase 3 — Inline Bots, Buttons, Real-Time Updates (7)**
-- `telegram-inline-query`, `telegram-inline-query-send`
-- `telegram-press-button`, `telegram-get-message-buttons`
-- `telegram-get-state`, `telegram-get-updates`, `telegram-get-channel-updates` (cursors are client-owned)
-
-**Phase 4 — Stories, Boosts, Business (8)**
-- `telegram-get-all-stories`, `telegram-get-peer-stories`, `telegram-get-stories-by-id`, `telegram-get-story-views`
-- `telegram-get-my-boosts`, `telegram-get-boosts-status`, `telegram-get-boosts-list`
-- `telegram-get-business-chat-links`
-
-**Phase 4 opt-in (6, env-gated)**
-- `MCP_TELEGRAM_ENABLE_GROUP_CALLS=1` → `telegram-get-group-call`, `telegram-get-group-call-participants`
-- `MCP_TELEGRAM_ENABLE_STARS=1` → `telegram-get-stars-status`, `telegram-get-stars-transactions`
-- `MCP_TELEGRAM_ENABLE_QUICK_REPLIES=1` → `telegram-get-quick-replies`, `telegram-get-quick-reply-messages`
+- **Phase 2 — Admin Toggles, Customization, Stats (8 tools)**
+  - `telegram-toggle-channel-signatures` — toggle post signatures on a channel
+  - `telegram-toggle-anti-spam` — toggle native anti-spam in a supergroup (`ban_users` admin)
+  - `telegram-toggle-forum-mode` — enable/disable forum mode on a supergroup (disable requires `confirm: true` — destructive, removes all topics)
+  - `telegram-approve-join-request` — approve or reject a single chat join request
+  - `telegram-toggle-prehistory-hidden` — show/hide pre-history for new supergroup members
+  - `telegram-set-chat-reactions` — set allowed reactions on a chat (`all` / `some` / `none`)
+  - `telegram-get-broadcast-stats` — channel stats overview (Premium admin may be required; pass `includeGraphs: true` for raw series)
+  - `telegram-get-megagroup-stats` — supergroup stats overview (rate-limited by Telegram to ~1 req/30 min per channel)
+- **Phase 3 — Inline Bots, Buttons, Real-Time Updates (7 tools)**
+  - `telegram-inline-query` — query an inline bot in a chat context (queryId TTL ≈ 1 min)
+  - `telegram-inline-query-send` — send an inline bot result by queryId + result id
+  - `telegram-press-button` — press a callback button on a message by row/col or raw data
+  - `telegram-get-message-buttons` — list a message's reply-markup buttons with indices and types
+  - `telegram-get-state` — initialize a polling cursor (`pts`, `qts`, `date`, `seq`)
+  - `telegram-get-updates` — fetch global updates since a known cursor via `updates.GetDifference`; returns `{newMessages, deletedMessageIds, otherUpdates, state, isFinal}` and surfaces `DifferenceTooLong` as a history-fallback hint
+  - `telegram-get-channel-updates` — per-channel polling via `updates.GetChannelDifference`
+  - Cursors are client-owned (stateless server) — the agent stores `{pts, qts, date}` between calls
+- **Phase 4 ship — Stories, Boosts, Business (8 tools)**
+  - `telegram-get-all-stories` — list stories across peers with pagination state
+  - `telegram-get-peer-stories` — list stories posted by one peer (compact, media refs only)
+  - `telegram-get-stories-by-id` — fetch specific story items by id
+  - `telegram-get-story-views` — list views on your own stories (Premium for full stats)
+  - `telegram-get-my-boosts` — list boost slots assigned by your account
+  - `telegram-get-boosts-status` — boost status for a channel/supergroup
+  - `telegram-get-boosts-list` — list boosters for a channel (admin)
+  - `telegram-get-business-chat-links` — list your Telegram Business chat links
+- **Phase 4 opt-in (env-gated, 6 tools)** — registered only when the corresponding flag is set:
+  - `MCP_TELEGRAM_ENABLE_GROUP_CALLS=1` → `telegram-get-group-call`, `telegram-get-group-call-participants`
+  - `MCP_TELEGRAM_ENABLE_STARS=1` → `telegram-get-stars-status`, `telegram-get-stars-transactions`
+  - `MCP_TELEGRAM_ENABLE_QUICK_REPLIES=1` → `telegram-get-quick-replies`, `telegram-get-quick-reply-messages`
 
 ## 1.25.0 — 2026-04-20 {#v1-25-0}
 
 ### Added
+
 - **Scheduled messages** — `telegram-get-scheduled`, `telegram-delete-scheduled`
 - **Threads & replies** — `telegram-get-replies` for channel post comments
-- **Message links** — `telegram-get-message-link` for public t.me URLs
+- **Message links** — `telegram-get-message-link` returns public t.me URL for a message
 - **Mentions & unread reactions** — `telegram-get-unread-mentions`, `telegram-get-unread-reactions`
-- **Translate** — `telegram-translate-message` (Telegram Premium)
-- **Typing indicator** — `telegram-send-typing`
+- **Translate** — `telegram-translate-message` (requires Telegram Premium)
+- **Typing indicator** — `telegram-send-typing` with configurable action
 - **Dialog management** — `telegram-archive-chat`, `telegram-pin-chat`, `telegram-mark-dialog-unread`
 - **Drafts** — `telegram-save-draft`, `telegram-get-drafts`, `telegram-clear-drafts`
-- **Saved Messages dialogs** — `telegram-get-saved-dialogs`
-- **Admin log** — `telegram-get-admin-log`
+- **Saved Messages dialogs** — `telegram-get-saved-dialogs` for the new per-peer Saved Messages folders
+- **Admin log** — `telegram-get-admin-log` for channel/supergroup moderation history
 - **Reactions catalog** — `telegram-set-default-reaction`, `telegram-get-top-reactions`, `telegram-get-recent-reactions`
-- **Chat permissions & slow mode** — `telegram-set-chat-permissions`, `telegram-set-slow-mode`
+- **Chat permissions** — `telegram-set-chat-permissions` for default banned rights
+- **Slow mode** — `telegram-set-slow-mode` for supergroups
 - **Forum topics CRUD** — `telegram-create-topic`, `telegram-edit-topic`, `telegram-delete-topic`
-- **Web page preview** — `telegram-get-web-preview`
+- **Web page preview** — `telegram-get-web-preview` to inspect link previews before sending
 
 ### Fixed
-- `telegram-set-chat-permissions` now merges with current `defaultBannedRights` — omitted flags keep their current state
-- `telegram-clear-drafts` requires `chatId` or `confirmAllChats: true` to wipe drafts account-wide
-- `telegram-get-unread-mentions` / `-reactions` annotated as `WRITE` — they mark listed items as read on the server
-- `telegram-translate-message` annotated as `WRITE`; `toLang` validated, `messageIds` capped at 1–100
-- `telegram-delete-scheduled` caps `messageIds` at 1–100 positive integers
-- `telegram-set-default-reaction` validates emoji length (1–8 characters)
-- `telegram-get-web-preview` rejects non-`http(s)` URLs (SSRF hardening)
-- `telegram-send-typing` throttles non-`cancel` actions to once per 10 s per chat
-- `telegram-get-saved-dialogs` drops the always-zero `unreadCount` field
-- `telegram-create-topic` now reads the new topic ID from `UpdateNewChannelMessage` and fails loudly if unavailable
-- `telegram-save-draft` drops `replyTo` when text is empty, avoiding `MESSAGE_EMPTY`
 
-## v1.24.1 <Badge type="tip" text="latest" /> {#v1.24.1}
-**2026-04-20**
+- `telegram-set-chat-permissions` now merges with the chat's current `defaultBannedRights` — omitted flags keep their current state instead of being silently cleared
+- `telegram-clear-drafts` requires `chatId` (single-chat) or `confirmAllChats: true` to wipe drafts account-wide, preventing accidental loss of all drafts in one call
+- `telegram-get-unread-mentions` and `telegram-get-unread-reactions` are now annotated as `WRITE` — they mark the listed items as read on the server
+- `telegram-translate-message` is now annotated as `WRITE` (consumes Premium translate quota); `toLang` is validated against an ISO-639 / locale pattern and `messageIds` is capped at 1–100 positive integers
+- `telegram-delete-scheduled` caps `messageIds` at 1–100 positive integers
+- `telegram-set-default-reaction` validates `emoji` length (1–8 characters)
+- `telegram-get-web-preview` rejects non-`http(s)` URLs, preventing use as an SSRF proxy
+- `telegram-send-typing` throttles non-`cancel` actions to once per 10 seconds per chat
+- `telegram-get-saved-dialogs` no longer returns a hard-coded `unreadCount: 0`
+- `telegram-create-topic` now reads the new topic ID from `UpdateNewChannelMessage` (authoritative) and fails loudly if neither source is available
+- `telegram-save-draft` drops `replyTo` when the draft text is empty, avoiding `MESSAGE_EMPTY` errors when clearing drafts
+- Removed unused `chatMap` build in `getAdminLog`
+
+## 1.24.1 — 2026-04-20 {#v1-24-1}
 
 ### Changed
-- Dependencies bumped to latest: `@modelcontextprotocol/sdk` 1.29.0, `dotenv` 17.4.2, `@biomejs/biome` 2.4.12, `typescript` 6.0.3, `@types/node` 25.6.0
 
-## v1.24.0 {#v1.24.0}
-**2026-04-06**
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.24.0 — 2026-04-06 {#v1-24-0}
 
 ### Added
+
 - **Sticker tools** — 5 new tools (59 total): `telegram-get-sticker-set`, `telegram-search-sticker-sets`, `telegram-get-installed-stickers`, `telegram-send-sticker`, `telegram-get-recent-stickers`
-- **Pre-built binaries** — zero-dependency standalone executables for Linux (x64/ARM64), macOS (x64/ARM64), Windows (x64)
-- **Documentation site** — VitePress-based docs with i18n (English, Russian, Chinese)
+- **Documentation site** — VitePress-based docs at overpod.github.io/mcp-telegram with i18n (English, Russian, Chinese)
 
-## v1.23.0 {#v1.23.0}
-**2026-04-05**
+## 1.23.0 — 2026-04-05 {#v1-23-0}
 
 ### Added
-- 11 new tools (22 total): reactions, edit/delete/forward messages, mark as read, dialogs, chat info, send file, add contact, create poll, manage topics
-- Account management: sessions, privacy, auto-delete, profile
+
+- 11 new tools (22 total): `telegram-send-reaction`, `telegram-edit-message`, `telegram-delete-message`, `telegram-forward-message`, `telegram-mark-as-read`, `telegram-get-dialogs`, `telegram-get-chat-info`, `telegram-send-file`, `telegram-add-contact`, `telegram-create-poll`, `telegram-manage-topics`
+- Account management tools: `telegram-get-sessions`, `telegram-terminate-session`, `telegram-set-privacy`, `telegram-set-auto-delete`, `telegram-update-profile`
 - Better entity resolution for channels and supergroups
 
-## v1.22.0 {#v1.22.0}
-**2026-04-01**
+## 1.22.0 — 2026-04-01 {#v1-22-0}
 
 ### Added
-- `TelegramService.setTyping()` — send typing indicators with 10 action types
-- `TelegramService.getMessageById()` — fetch a single message by ID
 
-## v1.21.0 {#v1.21.0}
-**2026-04-01**
+- `TelegramService.setTyping(chatId, action?)` — send typing indicators with 10 action types: `typing`, `cancel`, `record_video`, `upload_video`, `record_audio`, `upload_audio`, `upload_photo`, `upload_document`, `choose_sticker`, `game_play` (#17)
+- `TelegramService.getMessageById(chatId, messageId)` — fetch a single message by ID, returns formatted message object or `null`. Uses GramJS `ids` filter for exact lookup (#17)
 
-### Added
-- `TelegramService.getClient()` — public accessor for the underlying GramJS client
-
-## v1.20.0 {#v1.20.0}
-**2026-03-31**
+## 1.21.0 — 2026-04-01 {#v1-21-0}
 
 ### Added
-- **Rate limiting & retry** — automatic FLOOD_WAIT handling, network error recovery with exponential backoff
-- `send-message` now returns `messageId` in the response
 
-## v1.19.0 {#v1.19.0}
-**2026-03-30**
+- `TelegramService.getClient()` — public accessor for the underlying GramJS `TelegramClient` instance, enabling event handlers like `NewMessage` for real-time listeners (#17)
+
+## 1.20.0 — 2026-03-31 {#v1-20-0}
 
 ### Added
+
+- **Rate limiting & retry** — automatic FLOOD_WAIT handling, network error recovery with exponential backoff (`src/rate-limiter.ts`)
+- `send-message` now returns `messageId` in the response (`Message sent to @user [#12345]`), enabling send → edit workflows (closes #16)
+- Rate limiter unit tests (7 tests in `src/__tests__/rate-limiter.test.ts`)
+
+### Changed
+
+- `sendMessage()` return type changed from `void` to `Api.Message | Api.UpdateShortSentMessage | undefined`
+- Write methods (`sendMessage`, `sendFile`, `editMessage`, `deleteMessages`) are now rate-limited with automatic retry on transient errors
+
+## 1.19.0 — 2026-03-30 {#v1-19-0}
+
+### Added
+
 - Docker support for containerized deployment
 - Non-blocking startup behavior
 - Local QR code fallback for authentication
-- CI workflow for Docker images on GHCR
+- Automated test infrastructure with Node.js test runner
+- CI workflow to publish Docker images to GitHub Container Registry
 
-## v1.18.0 {#v1.18.0}
-**2026-03-28**
+## 1.18.0 — 2026-03-28 {#v1-18-0}
 
 ### Added
-- `telegram-get-my-role` tool
+
+- New `telegram-get-my-role` tool to check user's role in a chat
 - Role information in `telegram-get-chat-members` results
 
-## v1.17.0 {#v1.17.0}
-**2026-03-28**
+## 1.17.0 — 2026-03-28 {#v1-17-0}
 
 ### Added
-- Chat resolution by display name
 
-## v1.16.0 {#v1.16.0}
-**2026-03-28**
+- Chat resolution by display name (not just ID or username)
+
+### Changed
+
+- Updated documentation to replace static tool list with auto-discovery note
+- Improved project structure documentation
+
+## 1.16.0 — 2026-03-28 {#v1-16-0}
 
 ### Added
+
 - Group management tools: invite, kick, ban, edit, leave
 - Admin management capabilities
 
-## v1.15.0 {#v1.15.0}
-**2026-03-28**
+## 1.15.0 — 2026-03-28 {#v1-15-0}
 
 ### Added
-- `telegram-create-group` tool
 
-## v1.14.0 {#v1.14.0}
-**2026-03-28**
+- `telegram-create-group` tool for creating new groups
+
+### Fixed
+
+- Documented `AUTH_KEY_DUPLICATED` error handling
+
+## 1.14.0 — 2026-03-28 {#v1-14-0}
 
 ### Added
-- SOCKS5 and MTProxy support
 
-## v1.13.0 {#v1.13.0}
-**2026-03-26**
+- SOCKS5 proxy support for Telegram connections
+- MTProxy support for Telegram connections
 
 ### Changed
+
+- Added proxy documentation to README
+
+## 1.13.0 — 2026-03-26 {#v1-13-0}
+
+### Changed
+
 - Refactored tools into modular files organized by category
 
-## v1.12.0 {#v1.12.0}
-**2026-03-26**
+## 1.12.0 — 2026-03-26 {#v1-12-0}
 
 ### Changed
+
 - Migrated to `registerTool()` API with tool annotations
 
-## v1.11.0 {#v1.11.0}
-**2026-03-23**
+## 1.11.1 — 2026-03-25 {#v1-11-1}
 
-### Added
-- Full reactions support: read, send multiple reactions
-
-## v1.10.0 {#v1.10.0}
-**2026-03-20**
-
-### Added
-- Enhanced `telegram-get-profile` with birthday, business, and premium data
-- `telegram-get-profile-photo` tool
-- Global message search
-
-## v1.9.0 {#v1.9.0}
-**2026-03-18**
-
-### Added
-- Forum Topics support
-- Multiple accounts support
-- Secure session storage with configurable path
-
-## v1.8.0 {#v1.8.0}
-**2026-03-18**
-
-### Added
-- Secure session storage via `SESSION_PATH` environment variable
-
-## v1.7.0 {#v1.7.0}
-**2026-03-16**
-
-### Added
-- CI workflow for GitHub Packages publishing
-
-## v1.6.0 {#v1.6.0}
-**2026-03-16**
-
-### Added
-- Contact requests, block/unblock, report spam, add contact
-
-## v1.5.0 {#v1.5.0}
-**2026-03-16**
-
-### Added
-- Reactions, scheduled messages, polls, join chat
-
-## v1.4.0 {#v1.4.0}
-**2026-03-15**
-
-### Added
-- Glama.ai and Smithery catalog listings
-- Demo GIF and badges
-
-## v1.3.0 — v1.3.1 {#v1.3.0}
-**2026-03-12**
-
-### Added
-- `logOut()` method
 ### Fixed
-- GramJS update loop cleanup
 
-## v1.2.0 {#v1.2.0}
-**2026-03-11**
+- Sanitized unpaired UTF-16 surrogates in tool responses
+
+### Changed
+
+- Upgraded TypeScript to 6.0
+- Updated README with missing tools
+
+## 1.11.0 — 2026-03-23 {#v1-11-0}
 
 ### Added
-- Media download as buffer for serverless
+
+- Full reactions support: read, send multiple reactions, get detailed info
+
+### Changed
+
+- Included message ID in all message-reading tool outputs
+
+## 1.10.1 — 2026-03-22 {#v1-10-1}
+
+### Fixed
+
+- Message ID now included in all message-reading tool outputs
+
+## 1.10.0 — 2026-03-20 {#v1-10-0}
+
+### Added
+
+- Enhanced `telegram-get-profile` with birthday, business, and premium data
+- New `telegram-get-profile-photo` tool
+- Global message search capability
+- Enriched chat search results
+
+## 1.9.0 — 2026-03-18 {#v1-9-0}
+
+### Added
+
+- Forum Topics support
+- Per-topic unread count for forum groups
+- Secure session storage with configurable path
+- Multiple accounts support
+
+### Fixed
+
+- Per-topic unread sum calculation for forum groups
+
+### Changed
+
+- Updated session path and security documentation
+- Upgraded GitHub Actions to v6
+- Replaced Node 20 with Node 24 in CI
+
+## 1.8.1 — 2026-03-19 {#v1-8-1}
+
+### Fixed
+
+- Redirected console.log to stderr to prevent MCP JSON-RPC corruption
+
+## 1.8.0 — 2026-03-18 {#v1-8-0}
+
+### Added
+
+- Secure session storage with configurable path via SESSION_PATH environment variable
+
+### Changed
+
+- Updated session path and security information in README
+
+## 1.7.0 — 2026-03-16 {#v1-7-0}
+
+### Added
+
+- CI workflow to publish to GitHub Packages alongside npm
+- Manual workflow dispatch trigger for publishing
+
+## 1.6.0 — 2026-03-16 {#v1-6-0}
+
+### Added
+
+- Contact request management
+- Block/unblock users
+- Report spam functionality
+- Add contact tool
+- ChatGPT to list of supported clients
+
+### Changed
+
+- Removed hardcoded tool counts from README and package.json
+
+## 1.5.0 — 2026-03-16 {#v1-5-0}
+
+### Added
+
+- Reactions support
+- Scheduled messages
+- Polls creation and management
+- `telegram-join-chat` tool for joining groups and channels
+
+### Changed
+
+- Updated README with new tool documentation
+- Increased tool count to 24
+
+## 1.4.0 — 2026-03-15 {#v1-4-0}
+
+### Added
+
+- Glama.ai MCP catalog verification (glama.json)
+- Smithery MCP catalog listing (smithery.yaml)
+- Demo GIF and badges to README
+- Hosted version link
+
+### Fixed
+
+- Removed PNG file save from CLI QR login
+
+### Changed
+
+- Updated README with Glama MCP server badge
+
+## 1.3.1 — 2026-03-12 {#v1-3-1}
+
+### Fixed
+
+- Use `destroy()` instead of `disconnect()` to stop GramJS update loop
+- Adopt QR login client directly instead of destroy+reconnect flow
+- Destroy GramJS client in `logOut()` and `startQrLogin()` to stop update loop
+
+## 1.3.0 — 2026-03-12 {#v1-3-0}
+
+### Added
+
+- `logOut()` method for complete Telegram session termination
+
+## 1.2.0 — 2026-03-11 {#v1-2-0}
+
+### Added
+
+- `downloadMediaAsBuffer` for serverless media download
 - Library exports and declaration types
 - Date filters for messages
+- Comprehensive README for v1.0
 
-## v1.1.0 {#v1.1.0}
-**2026-03-11**
+### Fixed
+
+- MIME type detection from magic bytes in `downloadMediaAsBuffer`
+- Made `saveSession` resilient to file write errors in Docker
+
+### Changed
+
+- Use `GetFullChannel`/`GetFullChat` for complete chat information
+- Improved `telegram-login` for Claude Desktop users
+- Added npm publishing support and GitHub Actions CI/CD
+
+## 1.1.0 — 2026-03-11 {#v1-1-0}
 
 ### Added
-- Contacts, chat members, profiles, media, pin/unpin, markdown, unread, mark as read, forward, edit, delete, chat info, pagination
 
-## v1.0.0 {#v1.0.0}
-**2026-03-10**
+- Contact management tools
+- Chat members listing
+- User profile retrieval
+- Chat type filter
+- Media tools (send, download, get info)
+- Pin/unpin messages
+- Markdown support
+- Media information in messages
+- Unread counts
+- Mark messages as read
+- Forward messages
+- Edit messages
+- Delete messages
+- Detailed chat information
+- Pagination support
 
-### 🎉 Initial release
-- MCP server for Telegram userbot
+## 1.0.0 — 2026-03-10 {#v1-0-0}
+
+### Added
+
+- Initial release: MCP server for Telegram userbot
 - Basic message reading and sending
 - Chat listing
-- QR code and phone number authentication
+- Authentication via phone number and QR code
 - Session persistence
 - GramJS/MTProto integration

--- a/docs/ru/changelog.md
+++ b/docs/ru/changelog.md
@@ -1,160 +1,653 @@
 # Список изменений
 
-<VersionBadge version="1.26.0" /> Текущая версия
+<VersionBadge version="1.38.1" /> Текущая версия
 
-Все заметные изменения в MCP Telegram. Полные сравнения версий — на [GitHub Releases](https://github.com/mcp-telegram/mcp-telegram/releases).
+Все заметные изменения в MCP Telegram. Полное сравнение версий — на [GitHub Releases](https://github.com/mcp-telegram/mcp-telegram/releases). Записи приведены на английском (как в исходном CHANGELOG).
+
+<!-- Generated from CHANGELOG.md by scripts/gen-changelog-docs.ts. Do not edit by hand. -->
+
+## 1.38.1 — 2026-06-10 <Badge type="tip" text="latest" /> {#v1-38-1}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.38.0 — 2026-06-10 {#v1-38-0}
+
+### Added
+
+- shared daemon (serve mode) for concurrent MCP clients (#49)
+
+## 1.37.1 — 2026-06-06 {#v1-37-1}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.37.0 — 2026-06-04 {#v1-37-0}
+
+### Added
+
+- `TELEGRAM_USE_WSS` env-var. When set to `true`, gramJS uses port `443` instead of the default `80` for the MTProto TCPFull transport. This unblocks deployments on VPS/hosting IP ranges where outbound port `80` to Telegram DC IP blocks is dropped (anti-abuse policy on some shared-VPS providers), which otherwise hangs the client forever in `Connecting to ...:80/TCPFull...`. Default is `false`, so existing setups are unaffected. Contributed by Ivan Ponomarev (@Baho73).
+- When `TELEGRAM_USE_WSS=true` is combined with `TELEGRAM_PROXY_*` (which gramJS cannot do — SSL transport over a proxy is unsupported), the conflict is now detected early: a clear warning is logged and `useWSS` is ignored, letting the proxy take precedence, instead of crashing deep inside `connect()`.
+
+## 1.36.5 — 2026-06-01 {#v1-36-5}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.4 — 2026-05-28 {#v1-36-4}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.3 — 2026-05-10 {#v1-36-3}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.2 — 2026-05-10 {#v1-36-2}
+
+### Changed
+
+  - `hono` 4.12.9 → 4.12.18 (CSS injection in JSX SSR, JWT NumericDate, Cache `Vary`, etc.)
+  - `fast-uri` 3.1.0 → 3.1.2 (host confusion + path traversal)
+  - `ip-address` 10.1.0 → 10.2.0 (Address6 HTML XSS)
+  - `@hono/node-server` 1.19.11 → 1.19.14 (middleware bypass via repeated slashes)
+  - `express-rate-limit` 8.3.1 → 8.5.1
+- 3 remaining moderate advisories in `vitepress → vite → esbuild` are dev-only (docs site) with no upstream fix available.
+
+## 1.36.1 — 2026-05-04 {#v1-36-1}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.0 — 2026-04-28 {#v1-36-0}
+
+### Added
+
+- `destructiveHint: true` → `destructive`
+- `readOnlyHint: true` → `read-only`
+- otherwise → `write`
+
+### Notes
+
+- New public API surface; no breaking changes to existing exports.
+- `src/manifest.ts` and 13 new tests added; total test count: 505.
+- Build now sets executable bits on all `dist/*-cli.js` outputs (was npm-install-time only for `bin` entries).
+
+## 1.35.0 — 2026-04-25 {#v1-35-0}
+
+### Changed
+
+- `event` — event class (string literal)
+- `context` — caller-supplied operation name (never user input / PII)
+- `attempt` / `maxRetries` — retry counters
+- `seconds` (flood_wait only) or `delayMs` (network/temporary)
+- `error` (network/temporary only) — the upstream Telegram error message
+
+## 1.34.0 — 2026-04-24 {#v1-34-0}
+
+### Added
+
+- **telegram-get-available-star-gifts** — List all available Star Gift catalog items: gift ID, cost in Stars, conversion value, limited-edition availability, and upgrade cost
+- **telegram-get-saved-star-gifts** — List Star Gifts received by a user/chat. Supports pagination (`offset`/`nextOffset`), filter flags (`excludeUnsaved`, `excludeSaved`, `excludeUnlimited`, `excludeLimited`, `excludeUnique`), and `sortByValue`. Returns kind (regular/unique), from-peer, date, and upgrade eligibility
+- **telegram-save-star-gift** — Show or hide a received gift on your profile. For personal gifts pass `msgId`; for chat/channel gifts pass `chatId` + `savedId`. Set `unsave=true` to hide, omit to show
+- **telegram-convert-star-gift** — Convert a received gift into Stars (non-reversible, removes gift from profile). Same addressing as save: `msgId` for personal, `chatId`+`savedId` for chat gifts
+- **telegram-get-stars-topup-options** — List available Stars top-up tiers with star count, currency, price amount (smallest currency units), and extended/standard tier flag
+- **telegram-get-stars-subscriptions** — List active Stars subscriptions for a peer (`me` for self). Returns subscription ID, peer, until date, billing period (seconds), price in Stars, canceled status, and title. Pagination via `offset`
+- **telegram-change-stars-subscription** — Cancel or restore a Stars subscription by ID. `canceled=true` to cancel before next renewal, `canceled=false` to restore
+
+## 1.33.0 — 2026-04-24 {#v1-33-0}
+
+### Added
+
+- **telegram-create-folder** — Create a new chat folder. Accepts `title` (max 12 chars), optional `emoticon`, type flags (`contacts`, `nonContacts`, `groups`, `broadcasts`, `bots`), filter flags (`excludeMuted`, `excludeRead`, `excludeArchived`), and peer lists (`includePeers`, `excludePeers`, `pinnedPeers` max 5). Auto-assigns the next available folder ID ≥ 2. Returns the new ID
+- **telegram-edit-folder** — Edit an existing folder by `id`. Only pass fields to change — omitted fields preserve current values (fetches current state first via `messages.GetDialogFilters`)
+- **telegram-delete-folder** — Delete a chat folder by ID. Chats remain in All Chats. System folders (0 = All Chats, 1 = Archive) cannot be deleted. Uses `messages.UpdateDialogFilter` without a filter argument
+- **telegram-reorder-folders** — Set the display order of folders by passing an ordered array of folder IDs. Uses `messages.UpdateDialogFiltersOrder`
+- **telegram-get-suggested-folders** — Fetch Telegram's server-side folder suggestions based on your chat list (e.g. "Unread", "Work", "Personal"). Skips `DialogFilterDefault` entries that lack a title
+- **telegram-toggle-folder-tags** — Enable or disable folder tag labels on messages in chat lists. Requires Telegram Premium. Uses `messages.ToggleDialogFilterTags`
+- **telegram-get-global-privacy-settings** — Read all five global privacy flags: `archiveAndMuteNewNoncontactPeers`, `keepArchivedUnmuted`, `keepArchivedFolders`, `hideReadMarks`, `newNoncontactPeersRequirePremium`. Returns JSON
+- **telegram-set-global-privacy-settings** — Update any subset of global privacy flags. Fetches current settings first and merges only the fields you pass. `hideReadMarks` and `newNoncontactPeersRequirePremium` require Telegram Premium
+
+## 1.32.0 — 2026-04-24 {#v1-32-0}
+
+### Added
+
+- **telegram-set-emoji-status** — Set custom animated emoji status next to your name (Telegram Premium). Pass `documentId` or `collectibleId`; omit both to clear. Supports optional expiry via `untilUnix`
+- **telegram-list-emoji-statuses** — List available emoji statuses: `default`, `recent`, `channel_default`, or `collectible` (Premium). Returns `documentId`, `until`, collectible `title`/`slug`
+- **telegram-clear-recent-emoji-statuses** — Remove all entries from the "recent" emoji status picker section
+- **telegram-set-profile-color** — Set your name or profile background color. `forProfile=false` = chat list name color; `forProfile=true` = profile page background (Premium). Accepts color index 0-6 (free) or 7-20 (Premium) plus optional background pattern emoji
+- **telegram-set-birthday** — Add/update birthday on profile (`day` + `month` required, `year` optional to hide age). Pass `clear=true` to remove
+- **telegram-set-personal-channel** — Feature a channel on your profile as "Personal Channel". Pass `channelId` or `clear=true` to remove
+- **telegram-set-profile-photo** — Upload static (JPEG/PNG) or animated (MP4, square, ≤10s) avatar. Optional `fallback=true` sets it as the privacy fallback shown when your main photo is hidden
+- **telegram-delete-profile-photo** — Delete one or more profile photos by photo ID (stringified long). Fetches your photo history internally to build the required `InputPhoto`; reports which IDs were not found
+- **telegram-get-business-chat-links** — Moved from `account.ts` to new `business.ts` module. Behavior unchanged (read-only list of Business chat links)
+- **telegram-create-business-chat-link** — Create a `t.me/m/...` deep-link pre-filled with a message. Supports `parseMode` (md/html), optional admin `title`. Returns JSON with `link`, `slug`, `message`, `views`
+- **telegram-edit-business-chat-link** — Update an existing Business chat link by slug. Same options as create
+- **telegram-delete-business-chat-link** — Delete a Business chat link by slug
+- **telegram-resolve-business-chat-link** — Resolve a slug to see who it opens a chat with and the pre-filled message. Returns `peerId`, `peerType`, `message`, `entityCount`
+- **telegram-set-business-hours** — Configure weekly work hours (Telegram Business required). Input: `timezone` (IANA string) + `schedule` array of `{day, openFrom, openTo}` in HH:MM. Internally converts to minute-of-week (0–10079). `clear=true` disables
+- **telegram-set-business-location** — Set street address ± geo coordinates for Business profile. `clear=true` removes
+- **telegram-set-business-greeting** — Auto-reply for new conversations using a Quick Reply shortcut as template. `audience` enum (all_new / contacts_only / non_contacts / existing_only), `noActivityDays`, optional include/excludeUsers. `clear=true` disables
+- **telegram-set-business-away** — Auto-reply when offline or outside hours. `schedule` enum (always / outside_hours / custom). `custom` requires `customFrom`/`customTo` Unix timestamps. `offlineOnly` flag. Same audience model as greeting. `clear=true` disables
+- **telegram-set-business-intro** — Intro card shown to new users: `title` (≤32) + `description` (≤70) + optional sticker (requires `stickerId` + `stickerAccessHash` + `stickerFileReference` all together). `clear=true` removes
+
+### Notes
+
+- All Premium-gated tools (`telegram-set-emoji-status`, `telegram-set-profile-color` with index ≥ 7 or `backgroundEmojiId`) throw `PREMIUM_ACCOUNT_REQUIRED` from Telegram on non-Premium accounts — the error is propagated as-is
+- All Business-gated tools throw `BUSINESS_PEER_INVALID` or similar when the account lacks Telegram Business subscription
+- `telegram-get-business-chat-links` moved to `src/tools/business.ts` — tool name and behavior unchanged
+- `telegram-set-profile-photo`: uploads via GramJS `uploadFile` (4 workers). Video must be square MP4, ≤10s; server enforces its own size limits
+- `telegram-delete-profile-photo`: calls `photos.GetUserPhotos` first (up to 100) to resolve `accessHash` + `fileReference` from the photo ID; IDs not in your history are returned in `missing` array
+
+## 1.31.0 — 2026-04-24 {#v1-31-0}
+
+### Added
+
+- **telegram-vote-poll** — Vote in a poll by option index (single/multi-choice). Empty array retracts vote.
+- **telegram-get-poll-results** — Get aggregated poll results: vote counts, percentages, quiz answer status
+- **telegram-get-poll-voters** — List users who voted for specific poll options (public polls only, paginated)
+- **telegram-close-poll** — Permanently close a poll (irreversible; prevents further voting)
+- **telegram-transcribe-audio** — Start server-side transcription of a voice/video note (Telegram Premium)
+- **telegram-get-transcription** — Poll for updated transcription status (idempotent re-call)
+- **telegram-rate-transcription** — Rate transcription quality (good/poor) to improve speech-to-text
+- **telegram-get-fact-check** — Get fact-check annotations on channel messages (batch up to 100)
+- **telegram-edit-fact-check** — Add/update fact-check annotation (requires fact-checker privileges)
+- **telegram-delete-fact-check** — Remove fact-check annotation (requires fact-checker privileges)
+- **telegram-send-paid-reaction** — Send paid reaction (★ Stars) on a channel post with optional privacy
+- **telegram-toggle-paid-reaction-privacy** — Change leaderboard visibility of your paid reaction
+- **telegram-get-paid-reaction-privacy** — Get your current default paid reaction privacy setting
+
+### Notes
+
+- `telegram-close-poll`: One-way operation — closed polls cannot be reopened
+- `telegram-transcribe-audio`: Premium feature. Non-Premium accounts have limited free trials; `trialRemainsNum` shows count
+- `telegram-get-transcription`: Idempotent — returns same transcriptionId with updated text once processing completes
+- `telegram-edit-fact-check` / `telegram-delete-fact-check`: Require fact-checker privileges; regular users get permission errors
+- `telegram-send-paid-reaction`: Stars are debited from your Telegram balance; `count` range 1-2500
+- `telegram-toggle-paid-reaction-privacy`: Per-message toggle (Layer 198 API)
+
+### New helpers (exported from `telegram-client`)
+
+- `summarizePoll(poll, results?)` — summarize a GramJS Poll+PollResults into a compact typed object
+- `extractPollMediaFromUpdates(updates)` — extract poll + results from any Updates envelope
+- `extractPeerId(peer)` — convert TypePeer to string ID
+
+### Testing
+
+- 29 new mock-only tests (cumulative: 447 total)
+
+## 1.30.0 — 2026-04-24 {#v1-30-0}
+
+### Added
+
+- **telegram-send-story** — Publish a photo or video story to your profile or a channel with privacy controls (everyone/contacts/close_friends/selected), period (6-48h), pinning, and no-forward flag. Accepts absolute file path, auto-detects photo/video from extension (jpg/jpeg/png/webp/heic/heif → photo; everything else → video). Caption supports md/html parse mode.
+- **telegram-edit-story** — Edit an existing story: replace media, update caption (empty string clears it), or change privacy rules. At least one field (filePath, caption, or privacy) must be provided.
+- **telegram-delete-stories** — Delete one or more stories (irreversible; requires `confirm: true`; up to 100 IDs per call). Returns the actually-deleted IDs from Telegram (partial success possible).
+- **telegram-react-to-story** — React to a story with an emoji, or remove the reaction by passing empty string `""`.
+- **telegram-export-story-link** — Get a shareable `t.me/…` URL for a public story.
+- **telegram-read-stories** — Mark stories as seen up to a given story ID (maxId, inclusive). Returns count of newly-seen stories.
+- **telegram-toggle-story-pinned** — Pin/unpin stories in profile highlights (Telegram allows up to 3 pinned stories). Returns affected story IDs.
+- **telegram-toggle-story-pinned-to-top** — Pin stories to the very top of the pinned row; pass `[]` to clear all top-pinned stories.
+- **telegram-activate-stealth-mode** — Hide your story views retroactively (`past: true`) and/or for the next 25 minutes (`future: true`). At least one of past/future must be true. Requires Telegram Premium — non-Premium accounts receive PREMIUM_ACCOUNT_REQUIRED.
+- **telegram-get-stories-archive** — Fetch auto-archived (expired) stories from a peer's archive, paginated via `offsetId` + `limit` (1–100, default 50).
+- **telegram-report-story** — Report a story via Telegram's multi-step option flow. First call with `option: ""` starts the flow; subsequent calls pass the base64 option bytes from the previous response's `options[n].option` field.
+- **telegram-get-discussion-message** — For a channel post with comments enabled, returns the linked discussion-group info: `discussionGroupId`, `discussionMsgId`, `unreadCount`, `readInboxMaxId`, `readOutboxMaxId`, `topMessage`. Use `discussionGroupId` + `discussionMsgId` with `telegram-send-message` (replyTo=discussionMsgId) to post a comment.
+- **telegram-get-groups-for-discussion** — List groups eligible to link as discussion group to a channel you admin (channels.GetGroupsForDiscussion). No parameters required.
+- **telegram-get-message-read-participants** — List who has read a message in a small group (≤100 members, ≤7 days old). Returns `readers` array with `userId` and `readAt` (ISO timestamp). Returns CHAT_TOO_BIG error for large groups or channels.
+- **telegram-get-outbox-read-date** — Get when your recipient read your outgoing private message. Returns `"Read at <ISO date>"` or `"Not read yet"` (maps NOT_READ_YET error to null). Propagates YOUR_PRIVACY_RESTRICTED / USER_PRIVACY_RESTRICTED as errors.
+
+### New helpers in `telegram-helpers.ts`
+
+- `StoryPrivacy` type and `buildStoryPrivacyRules()` — builds GramJS `TypeInputPrivacyRule[]` from privacy enum + allow/disallow user ID lists
+- `detectMediaType()` — infers photo/video from file extension (safe default: video)
+- `extractStoryIdFromUpdates()` — extracts story ID from SendStory Updates envelope (prefers UpdateStoryID, falls back to UpdateStory)
+- `summarizeDiscussionMessage()`, `DiscussionMessageSummary` type
+- `summarizeGroupsForDiscussion()`, `GroupsForDiscussionSummary` type
+- `summarizeReadParticipants()`, `ReadParticipantsSummary` type
+- `summarizeReportResult()`, `ReportResultSummary` type (discriminated union: reported / chooseOption / addComment)
+
+### Notes
+
+- `telegram-activate-stealth-mode` requires Telegram Premium — non-Premium accounts receive PREMIUM_ACCOUNT_REQUIRED
+- `telegram-get-message-read-participants` only works for groups ≤100 members and messages ≤7 days old
+- `telegram-delete-stories` requires `confirm: true` (irreversible)
+- `telegram-send-story`: MediaAreas (venue/reaction/URL tags on the story frame) are not supported in this version
+- `telegram-report-story`: Multi-step flow — first call with `option: ""` starts the flow; subsequent calls pass the base64 option bytes from the previous response
+
+### Testing
+
+- 45 new mock-only tests in `src/__tests__/stories-v2.test.ts` (cumulative: 418 total)
+
+## 1.29.0 — 2026-04-23 {#v1-29-0}
+
+### Added
+
+- **Phase 5 Block A — Rich media sending (7 new tools)** — functional parity with Telegram UI for content types that could not be sent before.
+  - `telegram-send-voice` — send a voice note (OGG/Opus preferred) with optional caption, parseMode, reply/topic. Shows as a waveform UI in the chat.
+  - `telegram-send-video-note` — send a round-shaped video message (MP4, square recommended; duration ≤60s enforced client-side, length ≤640px).
+  - `telegram-send-location` — send a geographic location; single tool handles both static pins and live-updating locations (`livePeriod` 60–86400 seconds; optional `heading` 1–360°, `proximityRadius` meters).
+  - `telegram-send-venue` — send a venue card (title, address, lat/long + optional provider-specific metadata).
+  - `telegram-send-contact` — send a contact card (phone number in E.164-like format `^\+?\d{6,15}$`, first name, optional last name and vCard).
+  - `telegram-send-dice` — send an animated dice/game emoji (🎲 🎯 🎰 🏀 ⚽ 🎳) and receive the server-rolled value in the response.
+  - `telegram-send-album` — send 2–10 grouped photos/videos as a single album message with per-item or album-level caption.
+- **Block B — enhancements to existing `telegram-send-message`:**
+  - `quoteText` — attach a verbatim quote from the replied-to message (requires `replyTo`). Uses raw `messages.SendMessage` + `InputReplyToMessage.quoteText` under the hood.
+  - `effect` — Premium message effect ID (numeric string) attached to the outgoing message.
+- **Defence-in-depth for file-path inputs (`isSafeAbsolutePath`)** — all new `filePath` parameters reject:
+  - URL schemes (`http:`, `https:`, `file:`, `ftp:`, `data:`, `javascript:`, `ws:`, `wss:`) — no SSRF via GramJS URL-fetching.
+  - UNC / SMB shares (`\\server\share`, `//server/share`) — no NTLM-relay from Windows hosts.
+  - Path traversal (`..` segments inside an absolute path) — no escape out of the intended directory.
+  - POSIX pseudo-filesystems (`/proc`, `/sys`, `/dev`, `/run`) — prevents AI prompt-injection from reading `/proc/self/environ` and leaking env vars / session paths to Telegram.
+  - Embedded NUL byte and bare `/` — rejected explicitly.
+- **UTF-16 surrogate sanitation on input** — all free-text parameters (message `text`, captions, venue title/address/provider/venueId/venueType, contact name/vCard, quoteText) now strip unpaired surrogates before reaching GramJS's TL encoder. Complements the existing v1.11.1 output-side fix.
+- **Shared helpers in `telegram-helpers.ts`:**
+  - `buildReplyTo(replyTo?, topicId?)` — construct `InputReplyToMessage` (supports topic root where `replyToMsgId === topicId`).
+  - `generateRandomBigInt()` — cryptographically-random 64-bit `long` for TL `randomId`.
+  - `extractMessageId(result)` — unified parser across `Api.Updates`, `UpdatesCombined`, `Api.Message`, `UpdateShortSentMessage`, `UpdateNewMessage`, `UpdateNewChannelMessage`.
+  - `extractDiceResult(result)` — dice-specific extractor returning `{id, value?}` from `MessageMediaDice`.
+
+### Changed
+
+- `telegram-send-contact`: `phone` field now validated against `^\+?\d{6,15}$` (E.164-like) to reject malformed/hallucinated numbers.
+- `telegram-send-venue`: `provider` relaxed from a 2-value enum to a free string (≤32 chars) to match TL `venueProvider: string`.
+- `TelegramService.sendMessage()`: gained an optional 6th `extra: { quoteText?, effect? }` parameter. When set, falls back to raw `messages.SendMessage` (high-level `client.sendMessage` does not support these fields). Backward-compatible — existing callers see no change.
+
+### Security
+
+- `quoteText` without `replyTo` now raises a clear error instead of silently dropping the quote.
+- `effect` ID regex tightened to `^\d{1,19}$` (Int64-safe range).
+
+### Testing
+
+- 371 unit tests (was 322 in v1.28.1, +49). All tests mock-only (no live Telegram connection).
+- New coverage: all 8 new/changed service methods, helper edge cases (channel path, combined updates, direct Api.Message, UpdateShortSentMessage), SSRF guard (POSIX/Windows accept + URL/UNC/traversal/pseudo-fs reject), raw-path `sendMessage` with `quoteText` / `effect`.
+
+### Notes & known limitations
+
+- **`telegram-send-video-note` caption omitted** — Telegram UI does not render captions under round video notes; including it here would silently drop.
+- **`telegram-send-contact.userId` field dropped** — GramJS 2.26.22 `InputMediaContact` TL schema (Layer 198) has no `userId` slot. The card is standalone; recipients see the number and name, not a link to a Telegram user. Will return once GramJS advances.
+- **TTL / self-destruct media** — deferred. Requires raw `InputMediaUploadedPhoto({ttlSeconds})` path which bypasses the high-level `sendFile`; will ship in a follow-up.
+- **`telegram-send-voice.duration` removed vs. initial design** — GramJS auto-detects duration from the audio file; letting the AI override it caused the Telegram UI to display wrong playback times.
+- **Album mixed photo+video** — GramJS accepts mixed arrays via extension-based detection, but this is not covered by tests; recommend uniform media type per album until a live-test checkpoint confirms.
+- **Album flood control** — a 10-item album fans out 10 `messages.UploadMedia` calls inside one rate-limit slot; under heavy contention the later items may still hit `FLOOD_WAIT`. Rate limiter retries apply.
 
 ## 1.26.0 — 2026-04-20 {#v1-26-0}
 
-### Добавлено (29 новых инструментов)
+### Added
 
-**Phase 2 — админ-переключатели, кастомизация, статистика (8)**
-- `telegram-toggle-channel-signatures`, `telegram-toggle-anti-spam`, `telegram-toggle-forum-mode` (при отключении удаляет темы; требует `confirm: true`)
-- `telegram-toggle-prehistory-hidden`, `telegram-set-chat-reactions`
-- `telegram-approve-join-request`
-- `telegram-get-broadcast-stats`, `telegram-get-megagroup-stats`
-
-**Phase 3 — инлайн-боты, кнопки, обновления в реальном времени (7)**
-- `telegram-inline-query`, `telegram-inline-query-send`
-- `telegram-press-button`, `telegram-get-message-buttons`
-- `telegram-get-state`, `telegram-get-updates`, `telegram-get-channel-updates` (курсоры хранит клиент)
-
-**Phase 4 — истории, бусты, Business (8)**
-- `telegram-get-all-stories`, `telegram-get-peer-stories`, `telegram-get-stories-by-id`, `telegram-get-story-views`
-- `telegram-get-my-boosts`, `telegram-get-boosts-status`, `telegram-get-boosts-list`
-- `telegram-get-business-chat-links`
-
-**Phase 4 opt-in (6, по env-флагам)**
-- `MCP_TELEGRAM_ENABLE_GROUP_CALLS=1` → `telegram-get-group-call`, `telegram-get-group-call-participants`
-- `MCP_TELEGRAM_ENABLE_STARS=1` → `telegram-get-stars-status`, `telegram-get-stars-transactions`
-- `MCP_TELEGRAM_ENABLE_QUICK_REPLIES=1` → `telegram-get-quick-replies`, `telegram-get-quick-reply-messages`
+- **Phase 2 — Admin Toggles, Customization, Stats (8 tools)**
+  - `telegram-toggle-channel-signatures` — toggle post signatures on a channel
+  - `telegram-toggle-anti-spam` — toggle native anti-spam in a supergroup (`ban_users` admin)
+  - `telegram-toggle-forum-mode` — enable/disable forum mode on a supergroup (disable requires `confirm: true` — destructive, removes all topics)
+  - `telegram-approve-join-request` — approve or reject a single chat join request
+  - `telegram-toggle-prehistory-hidden` — show/hide pre-history for new supergroup members
+  - `telegram-set-chat-reactions` — set allowed reactions on a chat (`all` / `some` / `none`)
+  - `telegram-get-broadcast-stats` — channel stats overview (Premium admin may be required; pass `includeGraphs: true` for raw series)
+  - `telegram-get-megagroup-stats` — supergroup stats overview (rate-limited by Telegram to ~1 req/30 min per channel)
+- **Phase 3 — Inline Bots, Buttons, Real-Time Updates (7 tools)**
+  - `telegram-inline-query` — query an inline bot in a chat context (queryId TTL ≈ 1 min)
+  - `telegram-inline-query-send` — send an inline bot result by queryId + result id
+  - `telegram-press-button` — press a callback button on a message by row/col or raw data
+  - `telegram-get-message-buttons` — list a message's reply-markup buttons with indices and types
+  - `telegram-get-state` — initialize a polling cursor (`pts`, `qts`, `date`, `seq`)
+  - `telegram-get-updates` — fetch global updates since a known cursor via `updates.GetDifference`; returns `{newMessages, deletedMessageIds, otherUpdates, state, isFinal}` and surfaces `DifferenceTooLong` as a history-fallback hint
+  - `telegram-get-channel-updates` — per-channel polling via `updates.GetChannelDifference`
+  - Cursors are client-owned (stateless server) — the agent stores `{pts, qts, date}` between calls
+- **Phase 4 ship — Stories, Boosts, Business (8 tools)**
+  - `telegram-get-all-stories` — list stories across peers with pagination state
+  - `telegram-get-peer-stories` — list stories posted by one peer (compact, media refs only)
+  - `telegram-get-stories-by-id` — fetch specific story items by id
+  - `telegram-get-story-views` — list views on your own stories (Premium for full stats)
+  - `telegram-get-my-boosts` — list boost slots assigned by your account
+  - `telegram-get-boosts-status` — boost status for a channel/supergroup
+  - `telegram-get-boosts-list` — list boosters for a channel (admin)
+  - `telegram-get-business-chat-links` — list your Telegram Business chat links
+- **Phase 4 opt-in (env-gated, 6 tools)** — registered only when the corresponding flag is set:
+  - `MCP_TELEGRAM_ENABLE_GROUP_CALLS=1` → `telegram-get-group-call`, `telegram-get-group-call-participants`
+  - `MCP_TELEGRAM_ENABLE_STARS=1` → `telegram-get-stars-status`, `telegram-get-stars-transactions`
+  - `MCP_TELEGRAM_ENABLE_QUICK_REPLIES=1` → `telegram-get-quick-replies`, `telegram-get-quick-reply-messages`
 
 ## 1.25.0 — 2026-04-20 {#v1-25-0}
 
-### Добавлено
-- **Отложенные сообщения** — `telegram-get-scheduled`, `telegram-delete-scheduled`
-- **Треды и комментарии** — `telegram-get-replies` для комментариев под постом канала
-- **Ссылка на сообщение** — `telegram-get-message-link` возвращает публичную t.me-ссылку
-- **Упоминания и непрочитанные реакции** — `telegram-get-unread-mentions`, `telegram-get-unread-reactions`
-- **Перевод** — `telegram-translate-message` (нужен Telegram Premium)
-- **Индикатор набора** — `telegram-send-typing`
-- **Управление диалогами** — `telegram-archive-chat`, `telegram-pin-chat`, `telegram-mark-dialog-unread`
-- **Черновики** — `telegram-save-draft`, `telegram-get-drafts`, `telegram-clear-drafts`
-- **Saved Messages папки** — `telegram-get-saved-dialogs`
-- **Админ-лог** — `telegram-get-admin-log`
-- **Каталог реакций** — `telegram-set-default-reaction`, `telegram-get-top-reactions`, `telegram-get-recent-reactions`
-- **Права чата и slow mode** — `telegram-set-chat-permissions`, `telegram-set-slow-mode`
-- **CRUD топиков форума** — `telegram-create-topic`, `telegram-edit-topic`, `telegram-delete-topic`
-- **Превью веб-страницы** — `telegram-get-web-preview`
+### Added
 
-### Исправлено
-- `telegram-set-chat-permissions` теперь сливает новые флаги с текущими `defaultBannedRights` — опущенные флаги сохраняют текущее значение, а не сбрасываются молча
-- `telegram-clear-drafts` требует `chatId` или `confirmAllChats: true` для очистки черновиков во всех чатах
-- `telegram-get-unread-mentions` / `-reactions` переведены в annotation `WRITE` — эти методы помечают перечисленные элементы прочитанными на сервере
-- `telegram-translate-message` переведён в `WRITE`; `toLang` валидируется, `messageIds` ограничен 1–100
-- `telegram-delete-scheduled` ограничивает `messageIds` диапазоном 1–100 положительных int
-- `telegram-set-default-reaction` валидирует длину emoji (1–8 символов)
-- `telegram-get-web-preview` отвергает URL кроме `http(s)` — защита от использования Telegram как SSRF-прокси
-- `telegram-send-typing` троттлит не-`cancel` действия до одного раза в 10 с на чат
-- `telegram-get-saved-dialogs` больше не возвращает всегда-ноль `unreadCount`
-- `telegram-create-topic` берёт ID нового топика из `UpdateNewChannelMessage` (authoritative) и падает явно, если источника нет
-- `telegram-save-draft` сбрасывает `replyTo`, когда текст пустой — чтобы не получать `MESSAGE_EMPTY` при очистке черновика
+- **Scheduled messages** — `telegram-get-scheduled`, `telegram-delete-scheduled`
+- **Threads & replies** — `telegram-get-replies` for channel post comments
+- **Message links** — `telegram-get-message-link` returns public t.me URL for a message
+- **Mentions & unread reactions** — `telegram-get-unread-mentions`, `telegram-get-unread-reactions`
+- **Translate** — `telegram-translate-message` (requires Telegram Premium)
+- **Typing indicator** — `telegram-send-typing` with configurable action
+- **Dialog management** — `telegram-archive-chat`, `telegram-pin-chat`, `telegram-mark-dialog-unread`
+- **Drafts** — `telegram-save-draft`, `telegram-get-drafts`, `telegram-clear-drafts`
+- **Saved Messages dialogs** — `telegram-get-saved-dialogs` for the new per-peer Saved Messages folders
+- **Admin log** — `telegram-get-admin-log` for channel/supergroup moderation history
+- **Reactions catalog** — `telegram-set-default-reaction`, `telegram-get-top-reactions`, `telegram-get-recent-reactions`
+- **Chat permissions** — `telegram-set-chat-permissions` for default banned rights
+- **Slow mode** — `telegram-set-slow-mode` for supergroups
+- **Forum topics CRUD** — `telegram-create-topic`, `telegram-edit-topic`, `telegram-delete-topic`
+- **Web page preview** — `telegram-get-web-preview` to inspect link previews before sending
 
-## v1.24.1 <Badge type="tip" text="актуальная" /> {#v1.24.1}
-**2026-04-20**
+### Fixed
 
-### Изменено
-- Зависимости обновлены до последних версий: `@modelcontextprotocol/sdk` 1.29.0, `dotenv` 17.4.2, `@biomejs/biome` 2.4.12, `typescript` 6.0.3, `@types/node` 25.6.0
+- `telegram-set-chat-permissions` now merges with the chat's current `defaultBannedRights` — omitted flags keep their current state instead of being silently cleared
+- `telegram-clear-drafts` requires `chatId` (single-chat) or `confirmAllChats: true` to wipe drafts account-wide, preventing accidental loss of all drafts in one call
+- `telegram-get-unread-mentions` and `telegram-get-unread-reactions` are now annotated as `WRITE` — they mark the listed items as read on the server
+- `telegram-translate-message` is now annotated as `WRITE` (consumes Premium translate quota); `toLang` is validated against an ISO-639 / locale pattern and `messageIds` is capped at 1–100 positive integers
+- `telegram-delete-scheduled` caps `messageIds` at 1–100 positive integers
+- `telegram-set-default-reaction` validates `emoji` length (1–8 characters)
+- `telegram-get-web-preview` rejects non-`http(s)` URLs, preventing use as an SSRF proxy
+- `telegram-send-typing` throttles non-`cancel` actions to once per 10 seconds per chat
+- `telegram-get-saved-dialogs` no longer returns a hard-coded `unreadCount: 0`
+- `telegram-create-topic` now reads the new topic ID from `UpdateNewChannelMessage` (authoritative) and fails loudly if neither source is available
+- `telegram-save-draft` drops `replyTo` when the draft text is empty, avoiding `MESSAGE_EMPTY` errors when clearing drafts
+- Removed unused `chatMap` build in `getAdminLog`
 
-## v1.24.0 {#v1.24.0}
-**2026-04-06**
+## 1.24.1 — 2026-04-20 {#v1-24-1}
 
-### Добавлено
-- **Стикеры** — 5 новых инструментов (59 всего): `telegram-get-sticker-set`, `telegram-search-sticker-sets`, `telegram-get-installed-stickers`, `telegram-send-sticker`, `telegram-get-recent-stickers`
-- **Готовые бинарники** — самостоятельные исполняемые файлы без зависимостей для Linux (x64/ARM64), macOS (x64/ARM64), Windows (x64)
-- **Сайт документации** — на VitePress с поддержкой языков (English, Русский, 中文)
+### Changed
 
-## v1.23.0 {#v1.23.0}
-**2026-04-05**
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
 
-### Добавлено
-- 11 новых инструментов (22 всего): реакции, редактирование/удаление/пересылка сообщений, чтение, диалоги, информация о чате, отправка файлов, контакты, опросы, топики
-- Управление аккаунтом: сессии, приватность, автоудаление, профиль
+## 1.24.0 — 2026-04-06 {#v1-24-0}
 
-## v1.22.0 {#v1.22.0}
-**2026-04-01**
+### Added
 
-### Добавлено
-- Индикаторы набора текста (10 типов действий)
-- Получение сообщения по ID
+- **Sticker tools** — 5 new tools (59 total): `telegram-get-sticker-set`, `telegram-search-sticker-sets`, `telegram-get-installed-stickers`, `telegram-send-sticker`, `telegram-get-recent-stickers`
+- **Documentation site** — VitePress-based docs at overpod.github.io/mcp-telegram with i18n (English, Russian, Chinese)
 
-## v1.21.0 {#v1.21.0}
-**2026-04-01**
+## 1.23.0 — 2026-04-05 {#v1-23-0}
 
-### Добавлено
-- Публичный доступ к GramJS клиенту
+### Added
 
-## v1.20.0 {#v1.20.0}
-**2026-03-31**
+- 11 new tools (22 total): `telegram-send-reaction`, `telegram-edit-message`, `telegram-delete-message`, `telegram-forward-message`, `telegram-mark-as-read`, `telegram-get-dialogs`, `telegram-get-chat-info`, `telegram-send-file`, `telegram-add-contact`, `telegram-create-poll`, `telegram-manage-topics`
+- Account management tools: `telegram-get-sessions`, `telegram-terminate-session`, `telegram-set-privacy`, `telegram-set-auto-delete`, `telegram-update-profile`
+- Better entity resolution for channels and supergroups
 
-### Добавлено
-- Автоматическое ограничение запросов с обработкой FLOOD_WAIT
-- `send-message` возвращает `messageId`
+## 1.22.0 — 2026-04-01 {#v1-22-0}
 
-## v1.19.0 {#v1.19.0}
-**2026-03-30**
+### Added
 
-### Добавлено
-- Поддержка Docker
-- Неблокирующий запуск
-- QR-код сохраняется локально
+- `TelegramService.setTyping(chatId, action?)` — send typing indicators with 10 action types: `typing`, `cancel`, `record_video`, `upload_video`, `record_audio`, `upload_audio`, `upload_photo`, `upload_document`, `choose_sticker`, `game_play` (#17)
+- `TelegramService.getMessageById(chatId, messageId)` — fetch a single message by ID, returns formatted message object or `null`. Uses GramJS `ids` filter for exact lookup (#17)
 
-## v1.18.0 — v1.14.0 {#v1.18.0}
-**2026-03-28**
+## 1.21.0 — 2026-04-01 {#v1-21-0}
 
-### Добавлено
-- Проверка роли в чате
-- Резолюция чатов по имени
-- Управление группами: приглашение, кик, бан, редактирование
-- Создание групп
-- SOCKS5 и MTProxy
+### Added
 
-## v1.13.0 — v1.12.0 {#v1.13.0}
-**2026-03-26**
+- `TelegramService.getClient()` — public accessor for the underlying GramJS `TelegramClient` instance, enabling event handlers like `NewMessage` for real-time listeners (#17)
 
-### Изменено
-- Рефакторинг инструментов в модульные файлы
-- Миграция на `registerTool()` API
+## 1.20.0 — 2026-03-31 {#v1-20-0}
 
-## v1.11.0 — v1.9.0 {#v1.11.0}
-**2026-03-18 — 2026-03-23**
+### Added
 
-### Добавлено
-- Полная поддержка реакций
-- Топики форумов
-- Несколько аккаунтов
-- Безопасное хранение сессии
+- **Rate limiting & retry** — automatic FLOOD_WAIT handling, network error recovery with exponential backoff (`src/rate-limiter.ts`)
+- `send-message` now returns `messageId` in the response (`Message sent to @user [#12345]`), enabling send → edit workflows (closes #16)
+- Rate limiter unit tests (7 tests in `src/__tests__/rate-limiter.test.ts`)
 
-## v1.8.0 — v1.5.0 {#v1.8.0}
-**2026-03-16 — 2026-03-18**
+### Changed
 
-### Добавлено
-- Управление контактами, блокировка, жалобы на спам
-- Реакции, отложенные сообщения, опросы
-- Безопасное хранение сессии
+- `sendMessage()` return type changed from `void` to `Api.Message | Api.UpdateShortSentMessage | undefined`
+- Write methods (`sendMessage`, `sendFile`, `editMessage`, `deleteMessages`) are now rate-limited with automatic retry on transient errors
 
-## v1.4.0 — v1.1.0 {#v1.4.0}
-**2026-03-11 — 2026-03-15**
+## 1.19.0 — 2026-03-30 {#v1-19-0}
 
-### Добавлено
-- Каталоги Glama.ai и Smithery
-- Медиа, контакты, профили, пагинация, форвард, удаление
+### Added
 
-## v1.0.0 {#v1.0.0}
-**2026-03-10**
+- Docker support for containerized deployment
+- Non-blocking startup behavior
+- Local QR code fallback for authentication
+- Automated test infrastructure with Node.js test runner
+- CI workflow to publish Docker images to GitHub Container Registry
 
-### 🎉 Первый релиз
-- MCP-сервер для Telegram userbot
-- Чтение и отправка сообщений
-- Вход по QR-коду
-- Интеграция GramJS/MTProto
+## 1.18.0 — 2026-03-28 {#v1-18-0}
+
+### Added
+
+- New `telegram-get-my-role` tool to check user's role in a chat
+- Role information in `telegram-get-chat-members` results
+
+## 1.17.0 — 2026-03-28 {#v1-17-0}
+
+### Added
+
+- Chat resolution by display name (not just ID or username)
+
+### Changed
+
+- Updated documentation to replace static tool list with auto-discovery note
+- Improved project structure documentation
+
+## 1.16.0 — 2026-03-28 {#v1-16-0}
+
+### Added
+
+- Group management tools: invite, kick, ban, edit, leave
+- Admin management capabilities
+
+## 1.15.0 — 2026-03-28 {#v1-15-0}
+
+### Added
+
+- `telegram-create-group` tool for creating new groups
+
+### Fixed
+
+- Documented `AUTH_KEY_DUPLICATED` error handling
+
+## 1.14.0 — 2026-03-28 {#v1-14-0}
+
+### Added
+
+- SOCKS5 proxy support for Telegram connections
+- MTProxy support for Telegram connections
+
+### Changed
+
+- Added proxy documentation to README
+
+## 1.13.0 — 2026-03-26 {#v1-13-0}
+
+### Changed
+
+- Refactored tools into modular files organized by category
+
+## 1.12.0 — 2026-03-26 {#v1-12-0}
+
+### Changed
+
+- Migrated to `registerTool()` API with tool annotations
+
+## 1.11.1 — 2026-03-25 {#v1-11-1}
+
+### Fixed
+
+- Sanitized unpaired UTF-16 surrogates in tool responses
+
+### Changed
+
+- Upgraded TypeScript to 6.0
+- Updated README with missing tools
+
+## 1.11.0 — 2026-03-23 {#v1-11-0}
+
+### Added
+
+- Full reactions support: read, send multiple reactions, get detailed info
+
+### Changed
+
+- Included message ID in all message-reading tool outputs
+
+## 1.10.1 — 2026-03-22 {#v1-10-1}
+
+### Fixed
+
+- Message ID now included in all message-reading tool outputs
+
+## 1.10.0 — 2026-03-20 {#v1-10-0}
+
+### Added
+
+- Enhanced `telegram-get-profile` with birthday, business, and premium data
+- New `telegram-get-profile-photo` tool
+- Global message search capability
+- Enriched chat search results
+
+## 1.9.0 — 2026-03-18 {#v1-9-0}
+
+### Added
+
+- Forum Topics support
+- Per-topic unread count for forum groups
+- Secure session storage with configurable path
+- Multiple accounts support
+
+### Fixed
+
+- Per-topic unread sum calculation for forum groups
+
+### Changed
+
+- Updated session path and security documentation
+- Upgraded GitHub Actions to v6
+- Replaced Node 20 with Node 24 in CI
+
+## 1.8.1 — 2026-03-19 {#v1-8-1}
+
+### Fixed
+
+- Redirected console.log to stderr to prevent MCP JSON-RPC corruption
+
+## 1.8.0 — 2026-03-18 {#v1-8-0}
+
+### Added
+
+- Secure session storage with configurable path via SESSION_PATH environment variable
+
+### Changed
+
+- Updated session path and security information in README
+
+## 1.7.0 — 2026-03-16 {#v1-7-0}
+
+### Added
+
+- CI workflow to publish to GitHub Packages alongside npm
+- Manual workflow dispatch trigger for publishing
+
+## 1.6.0 — 2026-03-16 {#v1-6-0}
+
+### Added
+
+- Contact request management
+- Block/unblock users
+- Report spam functionality
+- Add contact tool
+- ChatGPT to list of supported clients
+
+### Changed
+
+- Removed hardcoded tool counts from README and package.json
+
+## 1.5.0 — 2026-03-16 {#v1-5-0}
+
+### Added
+
+- Reactions support
+- Scheduled messages
+- Polls creation and management
+- `telegram-join-chat` tool for joining groups and channels
+
+### Changed
+
+- Updated README with new tool documentation
+- Increased tool count to 24
+
+## 1.4.0 — 2026-03-15 {#v1-4-0}
+
+### Added
+
+- Glama.ai MCP catalog verification (glama.json)
+- Smithery MCP catalog listing (smithery.yaml)
+- Demo GIF and badges to README
+- Hosted version link
+
+### Fixed
+
+- Removed PNG file save from CLI QR login
+
+### Changed
+
+- Updated README with Glama MCP server badge
+
+## 1.3.1 — 2026-03-12 {#v1-3-1}
+
+### Fixed
+
+- Use `destroy()` instead of `disconnect()` to stop GramJS update loop
+- Adopt QR login client directly instead of destroy+reconnect flow
+- Destroy GramJS client in `logOut()` and `startQrLogin()` to stop update loop
+
+## 1.3.0 — 2026-03-12 {#v1-3-0}
+
+### Added
+
+- `logOut()` method for complete Telegram session termination
+
+## 1.2.0 — 2026-03-11 {#v1-2-0}
+
+### Added
+
+- `downloadMediaAsBuffer` for serverless media download
+- Library exports and declaration types
+- Date filters for messages
+- Comprehensive README for v1.0
+
+### Fixed
+
+- MIME type detection from magic bytes in `downloadMediaAsBuffer`
+- Made `saveSession` resilient to file write errors in Docker
+
+### Changed
+
+- Use `GetFullChannel`/`GetFullChat` for complete chat information
+- Improved `telegram-login` for Claude Desktop users
+- Added npm publishing support and GitHub Actions CI/CD
+
+## 1.1.0 — 2026-03-11 {#v1-1-0}
+
+### Added
+
+- Contact management tools
+- Chat members listing
+- User profile retrieval
+- Chat type filter
+- Media tools (send, download, get info)
+- Pin/unpin messages
+- Markdown support
+- Media information in messages
+- Unread counts
+- Mark messages as read
+- Forward messages
+- Edit messages
+- Delete messages
+- Detailed chat information
+- Pagination support
+
+## 1.0.0 — 2026-03-10 {#v1-0-0}
+
+### Added
+
+- Initial release: MCP server for Telegram userbot
+- Basic message reading and sending
+- Chat listing
+- Authentication via phone number and QR code
+- Session persistence
+- GramJS/MTProto integration

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -1,147 +1,653 @@
 # 更新日志
 
-<VersionBadge version="1.26.0" /> 当前版本
+<VersionBadge version="1.38.1" /> 当前版本
 
-MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](https://github.com/mcp-telegram/mcp-telegram/releases)。
+MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](https://github.com/mcp-telegram/mcp-telegram/releases)。条目以英文显示（与源 CHANGELOG 一致）。
+
+<!-- Generated from CHANGELOG.md by scripts/gen-changelog-docs.ts. Do not edit by hand. -->
+
+## 1.38.1 — 2026-06-10 <Badge type="tip" text="latest" /> {#v1-38-1}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.38.0 — 2026-06-10 {#v1-38-0}
+
+### Added
+
+- shared daemon (serve mode) for concurrent MCP clients (#49)
+
+## 1.37.1 — 2026-06-06 {#v1-37-1}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.37.0 — 2026-06-04 {#v1-37-0}
+
+### Added
+
+- `TELEGRAM_USE_WSS` env-var. When set to `true`, gramJS uses port `443` instead of the default `80` for the MTProto TCPFull transport. This unblocks deployments on VPS/hosting IP ranges where outbound port `80` to Telegram DC IP blocks is dropped (anti-abuse policy on some shared-VPS providers), which otherwise hangs the client forever in `Connecting to ...:80/TCPFull...`. Default is `false`, so existing setups are unaffected. Contributed by Ivan Ponomarev (@Baho73).
+- When `TELEGRAM_USE_WSS=true` is combined with `TELEGRAM_PROXY_*` (which gramJS cannot do — SSL transport over a proxy is unsupported), the conflict is now detected early: a clear warning is logged and `useWSS` is ignored, letting the proxy take precedence, instead of crashing deep inside `connect()`.
+
+## 1.36.5 — 2026-06-01 {#v1-36-5}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.4 — 2026-05-28 {#v1-36-4}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.3 — 2026-05-10 {#v1-36-3}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.2 — 2026-05-10 {#v1-36-2}
+
+### Changed
+
+  - `hono` 4.12.9 → 4.12.18 (CSS injection in JSX SSR, JWT NumericDate, Cache `Vary`, etc.)
+  - `fast-uri` 3.1.0 → 3.1.2 (host confusion + path traversal)
+  - `ip-address` 10.1.0 → 10.2.0 (Address6 HTML XSS)
+  - `@hono/node-server` 1.19.11 → 1.19.14 (middleware bypass via repeated slashes)
+  - `express-rate-limit` 8.3.1 → 8.5.1
+- 3 remaining moderate advisories in `vitepress → vite → esbuild` are dev-only (docs site) with no upstream fix available.
+
+## 1.36.1 — 2026-05-04 {#v1-36-1}
+
+### Changed
+
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+
+## 1.36.0 — 2026-04-28 {#v1-36-0}
+
+### Added
+
+- `destructiveHint: true` → `destructive`
+- `readOnlyHint: true` → `read-only`
+- otherwise → `write`
+
+### Notes
+
+- New public API surface; no breaking changes to existing exports.
+- `src/manifest.ts` and 13 new tests added; total test count: 505.
+- Build now sets executable bits on all `dist/*-cli.js` outputs (was npm-install-time only for `bin` entries).
+
+## 1.35.0 — 2026-04-25 {#v1-35-0}
+
+### Changed
+
+- `event` — event class (string literal)
+- `context` — caller-supplied operation name (never user input / PII)
+- `attempt` / `maxRetries` — retry counters
+- `seconds` (flood_wait only) or `delayMs` (network/temporary)
+- `error` (network/temporary only) — the upstream Telegram error message
+
+## 1.34.0 — 2026-04-24 {#v1-34-0}
+
+### Added
+
+- **telegram-get-available-star-gifts** — List all available Star Gift catalog items: gift ID, cost in Stars, conversion value, limited-edition availability, and upgrade cost
+- **telegram-get-saved-star-gifts** — List Star Gifts received by a user/chat. Supports pagination (`offset`/`nextOffset`), filter flags (`excludeUnsaved`, `excludeSaved`, `excludeUnlimited`, `excludeLimited`, `excludeUnique`), and `sortByValue`. Returns kind (regular/unique), from-peer, date, and upgrade eligibility
+- **telegram-save-star-gift** — Show or hide a received gift on your profile. For personal gifts pass `msgId`; for chat/channel gifts pass `chatId` + `savedId`. Set `unsave=true` to hide, omit to show
+- **telegram-convert-star-gift** — Convert a received gift into Stars (non-reversible, removes gift from profile). Same addressing as save: `msgId` for personal, `chatId`+`savedId` for chat gifts
+- **telegram-get-stars-topup-options** — List available Stars top-up tiers with star count, currency, price amount (smallest currency units), and extended/standard tier flag
+- **telegram-get-stars-subscriptions** — List active Stars subscriptions for a peer (`me` for self). Returns subscription ID, peer, until date, billing period (seconds), price in Stars, canceled status, and title. Pagination via `offset`
+- **telegram-change-stars-subscription** — Cancel or restore a Stars subscription by ID. `canceled=true` to cancel before next renewal, `canceled=false` to restore
+
+## 1.33.0 — 2026-04-24 {#v1-33-0}
+
+### Added
+
+- **telegram-create-folder** — Create a new chat folder. Accepts `title` (max 12 chars), optional `emoticon`, type flags (`contacts`, `nonContacts`, `groups`, `broadcasts`, `bots`), filter flags (`excludeMuted`, `excludeRead`, `excludeArchived`), and peer lists (`includePeers`, `excludePeers`, `pinnedPeers` max 5). Auto-assigns the next available folder ID ≥ 2. Returns the new ID
+- **telegram-edit-folder** — Edit an existing folder by `id`. Only pass fields to change — omitted fields preserve current values (fetches current state first via `messages.GetDialogFilters`)
+- **telegram-delete-folder** — Delete a chat folder by ID. Chats remain in All Chats. System folders (0 = All Chats, 1 = Archive) cannot be deleted. Uses `messages.UpdateDialogFilter` without a filter argument
+- **telegram-reorder-folders** — Set the display order of folders by passing an ordered array of folder IDs. Uses `messages.UpdateDialogFiltersOrder`
+- **telegram-get-suggested-folders** — Fetch Telegram's server-side folder suggestions based on your chat list (e.g. "Unread", "Work", "Personal"). Skips `DialogFilterDefault` entries that lack a title
+- **telegram-toggle-folder-tags** — Enable or disable folder tag labels on messages in chat lists. Requires Telegram Premium. Uses `messages.ToggleDialogFilterTags`
+- **telegram-get-global-privacy-settings** — Read all five global privacy flags: `archiveAndMuteNewNoncontactPeers`, `keepArchivedUnmuted`, `keepArchivedFolders`, `hideReadMarks`, `newNoncontactPeersRequirePremium`. Returns JSON
+- **telegram-set-global-privacy-settings** — Update any subset of global privacy flags. Fetches current settings first and merges only the fields you pass. `hideReadMarks` and `newNoncontactPeersRequirePremium` require Telegram Premium
+
+## 1.32.0 — 2026-04-24 {#v1-32-0}
+
+### Added
+
+- **telegram-set-emoji-status** — Set custom animated emoji status next to your name (Telegram Premium). Pass `documentId` or `collectibleId`; omit both to clear. Supports optional expiry via `untilUnix`
+- **telegram-list-emoji-statuses** — List available emoji statuses: `default`, `recent`, `channel_default`, or `collectible` (Premium). Returns `documentId`, `until`, collectible `title`/`slug`
+- **telegram-clear-recent-emoji-statuses** — Remove all entries from the "recent" emoji status picker section
+- **telegram-set-profile-color** — Set your name or profile background color. `forProfile=false` = chat list name color; `forProfile=true` = profile page background (Premium). Accepts color index 0-6 (free) or 7-20 (Premium) plus optional background pattern emoji
+- **telegram-set-birthday** — Add/update birthday on profile (`day` + `month` required, `year` optional to hide age). Pass `clear=true` to remove
+- **telegram-set-personal-channel** — Feature a channel on your profile as "Personal Channel". Pass `channelId` or `clear=true` to remove
+- **telegram-set-profile-photo** — Upload static (JPEG/PNG) or animated (MP4, square, ≤10s) avatar. Optional `fallback=true` sets it as the privacy fallback shown when your main photo is hidden
+- **telegram-delete-profile-photo** — Delete one or more profile photos by photo ID (stringified long). Fetches your photo history internally to build the required `InputPhoto`; reports which IDs were not found
+- **telegram-get-business-chat-links** — Moved from `account.ts` to new `business.ts` module. Behavior unchanged (read-only list of Business chat links)
+- **telegram-create-business-chat-link** — Create a `t.me/m/...` deep-link pre-filled with a message. Supports `parseMode` (md/html), optional admin `title`. Returns JSON with `link`, `slug`, `message`, `views`
+- **telegram-edit-business-chat-link** — Update an existing Business chat link by slug. Same options as create
+- **telegram-delete-business-chat-link** — Delete a Business chat link by slug
+- **telegram-resolve-business-chat-link** — Resolve a slug to see who it opens a chat with and the pre-filled message. Returns `peerId`, `peerType`, `message`, `entityCount`
+- **telegram-set-business-hours** — Configure weekly work hours (Telegram Business required). Input: `timezone` (IANA string) + `schedule` array of `{day, openFrom, openTo}` in HH:MM. Internally converts to minute-of-week (0–10079). `clear=true` disables
+- **telegram-set-business-location** — Set street address ± geo coordinates for Business profile. `clear=true` removes
+- **telegram-set-business-greeting** — Auto-reply for new conversations using a Quick Reply shortcut as template. `audience` enum (all_new / contacts_only / non_contacts / existing_only), `noActivityDays`, optional include/excludeUsers. `clear=true` disables
+- **telegram-set-business-away** — Auto-reply when offline or outside hours. `schedule` enum (always / outside_hours / custom). `custom` requires `customFrom`/`customTo` Unix timestamps. `offlineOnly` flag. Same audience model as greeting. `clear=true` disables
+- **telegram-set-business-intro** — Intro card shown to new users: `title` (≤32) + `description` (≤70) + optional sticker (requires `stickerId` + `stickerAccessHash` + `stickerFileReference` all together). `clear=true` removes
+
+### Notes
+
+- All Premium-gated tools (`telegram-set-emoji-status`, `telegram-set-profile-color` with index ≥ 7 or `backgroundEmojiId`) throw `PREMIUM_ACCOUNT_REQUIRED` from Telegram on non-Premium accounts — the error is propagated as-is
+- All Business-gated tools throw `BUSINESS_PEER_INVALID` or similar when the account lacks Telegram Business subscription
+- `telegram-get-business-chat-links` moved to `src/tools/business.ts` — tool name and behavior unchanged
+- `telegram-set-profile-photo`: uploads via GramJS `uploadFile` (4 workers). Video must be square MP4, ≤10s; server enforces its own size limits
+- `telegram-delete-profile-photo`: calls `photos.GetUserPhotos` first (up to 100) to resolve `accessHash` + `fileReference` from the photo ID; IDs not in your history are returned in `missing` array
+
+## 1.31.0 — 2026-04-24 {#v1-31-0}
+
+### Added
+
+- **telegram-vote-poll** — Vote in a poll by option index (single/multi-choice). Empty array retracts vote.
+- **telegram-get-poll-results** — Get aggregated poll results: vote counts, percentages, quiz answer status
+- **telegram-get-poll-voters** — List users who voted for specific poll options (public polls only, paginated)
+- **telegram-close-poll** — Permanently close a poll (irreversible; prevents further voting)
+- **telegram-transcribe-audio** — Start server-side transcription of a voice/video note (Telegram Premium)
+- **telegram-get-transcription** — Poll for updated transcription status (idempotent re-call)
+- **telegram-rate-transcription** — Rate transcription quality (good/poor) to improve speech-to-text
+- **telegram-get-fact-check** — Get fact-check annotations on channel messages (batch up to 100)
+- **telegram-edit-fact-check** — Add/update fact-check annotation (requires fact-checker privileges)
+- **telegram-delete-fact-check** — Remove fact-check annotation (requires fact-checker privileges)
+- **telegram-send-paid-reaction** — Send paid reaction (★ Stars) on a channel post with optional privacy
+- **telegram-toggle-paid-reaction-privacy** — Change leaderboard visibility of your paid reaction
+- **telegram-get-paid-reaction-privacy** — Get your current default paid reaction privacy setting
+
+### Notes
+
+- `telegram-close-poll`: One-way operation — closed polls cannot be reopened
+- `telegram-transcribe-audio`: Premium feature. Non-Premium accounts have limited free trials; `trialRemainsNum` shows count
+- `telegram-get-transcription`: Idempotent — returns same transcriptionId with updated text once processing completes
+- `telegram-edit-fact-check` / `telegram-delete-fact-check`: Require fact-checker privileges; regular users get permission errors
+- `telegram-send-paid-reaction`: Stars are debited from your Telegram balance; `count` range 1-2500
+- `telegram-toggle-paid-reaction-privacy`: Per-message toggle (Layer 198 API)
+
+### New helpers (exported from `telegram-client`)
+
+- `summarizePoll(poll, results?)` — summarize a GramJS Poll+PollResults into a compact typed object
+- `extractPollMediaFromUpdates(updates)` — extract poll + results from any Updates envelope
+- `extractPeerId(peer)` — convert TypePeer to string ID
+
+### Testing
+
+- 29 new mock-only tests (cumulative: 447 total)
+
+## 1.30.0 — 2026-04-24 {#v1-30-0}
+
+### Added
+
+- **telegram-send-story** — Publish a photo or video story to your profile or a channel with privacy controls (everyone/contacts/close_friends/selected), period (6-48h), pinning, and no-forward flag. Accepts absolute file path, auto-detects photo/video from extension (jpg/jpeg/png/webp/heic/heif → photo; everything else → video). Caption supports md/html parse mode.
+- **telegram-edit-story** — Edit an existing story: replace media, update caption (empty string clears it), or change privacy rules. At least one field (filePath, caption, or privacy) must be provided.
+- **telegram-delete-stories** — Delete one or more stories (irreversible; requires `confirm: true`; up to 100 IDs per call). Returns the actually-deleted IDs from Telegram (partial success possible).
+- **telegram-react-to-story** — React to a story with an emoji, or remove the reaction by passing empty string `""`.
+- **telegram-export-story-link** — Get a shareable `t.me/…` URL for a public story.
+- **telegram-read-stories** — Mark stories as seen up to a given story ID (maxId, inclusive). Returns count of newly-seen stories.
+- **telegram-toggle-story-pinned** — Pin/unpin stories in profile highlights (Telegram allows up to 3 pinned stories). Returns affected story IDs.
+- **telegram-toggle-story-pinned-to-top** — Pin stories to the very top of the pinned row; pass `[]` to clear all top-pinned stories.
+- **telegram-activate-stealth-mode** — Hide your story views retroactively (`past: true`) and/or for the next 25 minutes (`future: true`). At least one of past/future must be true. Requires Telegram Premium — non-Premium accounts receive PREMIUM_ACCOUNT_REQUIRED.
+- **telegram-get-stories-archive** — Fetch auto-archived (expired) stories from a peer's archive, paginated via `offsetId` + `limit` (1–100, default 50).
+- **telegram-report-story** — Report a story via Telegram's multi-step option flow. First call with `option: ""` starts the flow; subsequent calls pass the base64 option bytes from the previous response's `options[n].option` field.
+- **telegram-get-discussion-message** — For a channel post with comments enabled, returns the linked discussion-group info: `discussionGroupId`, `discussionMsgId`, `unreadCount`, `readInboxMaxId`, `readOutboxMaxId`, `topMessage`. Use `discussionGroupId` + `discussionMsgId` with `telegram-send-message` (replyTo=discussionMsgId) to post a comment.
+- **telegram-get-groups-for-discussion** — List groups eligible to link as discussion group to a channel you admin (channels.GetGroupsForDiscussion). No parameters required.
+- **telegram-get-message-read-participants** — List who has read a message in a small group (≤100 members, ≤7 days old). Returns `readers` array with `userId` and `readAt` (ISO timestamp). Returns CHAT_TOO_BIG error for large groups or channels.
+- **telegram-get-outbox-read-date** — Get when your recipient read your outgoing private message. Returns `"Read at <ISO date>"` or `"Not read yet"` (maps NOT_READ_YET error to null). Propagates YOUR_PRIVACY_RESTRICTED / USER_PRIVACY_RESTRICTED as errors.
+
+### New helpers in `telegram-helpers.ts`
+
+- `StoryPrivacy` type and `buildStoryPrivacyRules()` — builds GramJS `TypeInputPrivacyRule[]` from privacy enum + allow/disallow user ID lists
+- `detectMediaType()` — infers photo/video from file extension (safe default: video)
+- `extractStoryIdFromUpdates()` — extracts story ID from SendStory Updates envelope (prefers UpdateStoryID, falls back to UpdateStory)
+- `summarizeDiscussionMessage()`, `DiscussionMessageSummary` type
+- `summarizeGroupsForDiscussion()`, `GroupsForDiscussionSummary` type
+- `summarizeReadParticipants()`, `ReadParticipantsSummary` type
+- `summarizeReportResult()`, `ReportResultSummary` type (discriminated union: reported / chooseOption / addComment)
+
+### Notes
+
+- `telegram-activate-stealth-mode` requires Telegram Premium — non-Premium accounts receive PREMIUM_ACCOUNT_REQUIRED
+- `telegram-get-message-read-participants` only works for groups ≤100 members and messages ≤7 days old
+- `telegram-delete-stories` requires `confirm: true` (irreversible)
+- `telegram-send-story`: MediaAreas (venue/reaction/URL tags on the story frame) are not supported in this version
+- `telegram-report-story`: Multi-step flow — first call with `option: ""` starts the flow; subsequent calls pass the base64 option bytes from the previous response
+
+### Testing
+
+- 45 new mock-only tests in `src/__tests__/stories-v2.test.ts` (cumulative: 418 total)
+
+## 1.29.0 — 2026-04-23 {#v1-29-0}
+
+### Added
+
+- **Phase 5 Block A — Rich media sending (7 new tools)** — functional parity with Telegram UI for content types that could not be sent before.
+  - `telegram-send-voice` — send a voice note (OGG/Opus preferred) with optional caption, parseMode, reply/topic. Shows as a waveform UI in the chat.
+  - `telegram-send-video-note` — send a round-shaped video message (MP4, square recommended; duration ≤60s enforced client-side, length ≤640px).
+  - `telegram-send-location` — send a geographic location; single tool handles both static pins and live-updating locations (`livePeriod` 60–86400 seconds; optional `heading` 1–360°, `proximityRadius` meters).
+  - `telegram-send-venue` — send a venue card (title, address, lat/long + optional provider-specific metadata).
+  - `telegram-send-contact` — send a contact card (phone number in E.164-like format `^\+?\d{6,15}$`, first name, optional last name and vCard).
+  - `telegram-send-dice` — send an animated dice/game emoji (🎲 🎯 🎰 🏀 ⚽ 🎳) and receive the server-rolled value in the response.
+  - `telegram-send-album` — send 2–10 grouped photos/videos as a single album message with per-item or album-level caption.
+- **Block B — enhancements to existing `telegram-send-message`:**
+  - `quoteText` — attach a verbatim quote from the replied-to message (requires `replyTo`). Uses raw `messages.SendMessage` + `InputReplyToMessage.quoteText` under the hood.
+  - `effect` — Premium message effect ID (numeric string) attached to the outgoing message.
+- **Defence-in-depth for file-path inputs (`isSafeAbsolutePath`)** — all new `filePath` parameters reject:
+  - URL schemes (`http:`, `https:`, `file:`, `ftp:`, `data:`, `javascript:`, `ws:`, `wss:`) — no SSRF via GramJS URL-fetching.
+  - UNC / SMB shares (`\\server\share`, `//server/share`) — no NTLM-relay from Windows hosts.
+  - Path traversal (`..` segments inside an absolute path) — no escape out of the intended directory.
+  - POSIX pseudo-filesystems (`/proc`, `/sys`, `/dev`, `/run`) — prevents AI prompt-injection from reading `/proc/self/environ` and leaking env vars / session paths to Telegram.
+  - Embedded NUL byte and bare `/` — rejected explicitly.
+- **UTF-16 surrogate sanitation on input** — all free-text parameters (message `text`, captions, venue title/address/provider/venueId/venueType, contact name/vCard, quoteText) now strip unpaired surrogates before reaching GramJS's TL encoder. Complements the existing v1.11.1 output-side fix.
+- **Shared helpers in `telegram-helpers.ts`:**
+  - `buildReplyTo(replyTo?, topicId?)` — construct `InputReplyToMessage` (supports topic root where `replyToMsgId === topicId`).
+  - `generateRandomBigInt()` — cryptographically-random 64-bit `long` for TL `randomId`.
+  - `extractMessageId(result)` — unified parser across `Api.Updates`, `UpdatesCombined`, `Api.Message`, `UpdateShortSentMessage`, `UpdateNewMessage`, `UpdateNewChannelMessage`.
+  - `extractDiceResult(result)` — dice-specific extractor returning `{id, value?}` from `MessageMediaDice`.
+
+### Changed
+
+- `telegram-send-contact`: `phone` field now validated against `^\+?\d{6,15}$` (E.164-like) to reject malformed/hallucinated numbers.
+- `telegram-send-venue`: `provider` relaxed from a 2-value enum to a free string (≤32 chars) to match TL `venueProvider: string`.
+- `TelegramService.sendMessage()`: gained an optional 6th `extra: { quoteText?, effect? }` parameter. When set, falls back to raw `messages.SendMessage` (high-level `client.sendMessage` does not support these fields). Backward-compatible — existing callers see no change.
+
+### Security
+
+- `quoteText` without `replyTo` now raises a clear error instead of silently dropping the quote.
+- `effect` ID regex tightened to `^\d{1,19}$` (Int64-safe range).
+
+### Testing
+
+- 371 unit tests (was 322 in v1.28.1, +49). All tests mock-only (no live Telegram connection).
+- New coverage: all 8 new/changed service methods, helper edge cases (channel path, combined updates, direct Api.Message, UpdateShortSentMessage), SSRF guard (POSIX/Windows accept + URL/UNC/traversal/pseudo-fs reject), raw-path `sendMessage` with `quoteText` / `effect`.
+
+### Notes & known limitations
+
+- **`telegram-send-video-note` caption omitted** — Telegram UI does not render captions under round video notes; including it here would silently drop.
+- **`telegram-send-contact.userId` field dropped** — GramJS 2.26.22 `InputMediaContact` TL schema (Layer 198) has no `userId` slot. The card is standalone; recipients see the number and name, not a link to a Telegram user. Will return once GramJS advances.
+- **TTL / self-destruct media** — deferred. Requires raw `InputMediaUploadedPhoto({ttlSeconds})` path which bypasses the high-level `sendFile`; will ship in a follow-up.
+- **`telegram-send-voice.duration` removed vs. initial design** — GramJS auto-detects duration from the audio file; letting the AI override it caused the Telegram UI to display wrong playback times.
+- **Album mixed photo+video** — GramJS accepts mixed arrays via extension-based detection, but this is not covered by tests; recommend uniform media type per album until a live-test checkpoint confirms.
+- **Album flood control** — a 10-item album fans out 10 `messages.UploadMedia` calls inside one rate-limit slot; under heavy contention the later items may still hit `FLOOD_WAIT`. Rate limiter retries apply.
 
 ## 1.26.0 — 2026-04-20 {#v1-26-0}
 
-### 新增（29 个新工具）
+### Added
 
-**Phase 2 — 管理员开关、定制、统计（8 个）**
-- `telegram-toggle-channel-signatures`、`telegram-toggle-anti-spam`、`telegram-toggle-forum-mode`（禁用会删除所有主题，需 `confirm: true`）
-- `telegram-toggle-prehistory-hidden`、`telegram-set-chat-reactions`
-- `telegram-approve-join-request`
-- `telegram-get-broadcast-stats`、`telegram-get-megagroup-stats`
-
-**Phase 3 — 内联机器人、按钮、实时更新（7 个）**
-- `telegram-inline-query`、`telegram-inline-query-send`
-- `telegram-press-button`、`telegram-get-message-buttons`
-- `telegram-get-state`、`telegram-get-updates`、`telegram-get-channel-updates`（游标由客户端保存）
-
-**Phase 4 — 故事、助推、Business（8 个）**
-- `telegram-get-all-stories`、`telegram-get-peer-stories`、`telegram-get-stories-by-id`、`telegram-get-story-views`
-- `telegram-get-my-boosts`、`telegram-get-boosts-status`、`telegram-get-boosts-list`
-- `telegram-get-business-chat-links`
-
-**Phase 4 按需启用（6 个，env 门控）**
-- `MCP_TELEGRAM_ENABLE_GROUP_CALLS=1` → `telegram-get-group-call`、`telegram-get-group-call-participants`
-- `MCP_TELEGRAM_ENABLE_STARS=1` → `telegram-get-stars-status`、`telegram-get-stars-transactions`
-- `MCP_TELEGRAM_ENABLE_QUICK_REPLIES=1` → `telegram-get-quick-replies`、`telegram-get-quick-reply-messages`
+- **Phase 2 — Admin Toggles, Customization, Stats (8 tools)**
+  - `telegram-toggle-channel-signatures` — toggle post signatures on a channel
+  - `telegram-toggle-anti-spam` — toggle native anti-spam in a supergroup (`ban_users` admin)
+  - `telegram-toggle-forum-mode` — enable/disable forum mode on a supergroup (disable requires `confirm: true` — destructive, removes all topics)
+  - `telegram-approve-join-request` — approve or reject a single chat join request
+  - `telegram-toggle-prehistory-hidden` — show/hide pre-history for new supergroup members
+  - `telegram-set-chat-reactions` — set allowed reactions on a chat (`all` / `some` / `none`)
+  - `telegram-get-broadcast-stats` — channel stats overview (Premium admin may be required; pass `includeGraphs: true` for raw series)
+  - `telegram-get-megagroup-stats` — supergroup stats overview (rate-limited by Telegram to ~1 req/30 min per channel)
+- **Phase 3 — Inline Bots, Buttons, Real-Time Updates (7 tools)**
+  - `telegram-inline-query` — query an inline bot in a chat context (queryId TTL ≈ 1 min)
+  - `telegram-inline-query-send` — send an inline bot result by queryId + result id
+  - `telegram-press-button` — press a callback button on a message by row/col or raw data
+  - `telegram-get-message-buttons` — list a message's reply-markup buttons with indices and types
+  - `telegram-get-state` — initialize a polling cursor (`pts`, `qts`, `date`, `seq`)
+  - `telegram-get-updates` — fetch global updates since a known cursor via `updates.GetDifference`; returns `{newMessages, deletedMessageIds, otherUpdates, state, isFinal}` and surfaces `DifferenceTooLong` as a history-fallback hint
+  - `telegram-get-channel-updates` — per-channel polling via `updates.GetChannelDifference`
+  - Cursors are client-owned (stateless server) — the agent stores `{pts, qts, date}` between calls
+- **Phase 4 ship — Stories, Boosts, Business (8 tools)**
+  - `telegram-get-all-stories` — list stories across peers with pagination state
+  - `telegram-get-peer-stories` — list stories posted by one peer (compact, media refs only)
+  - `telegram-get-stories-by-id` — fetch specific story items by id
+  - `telegram-get-story-views` — list views on your own stories (Premium for full stats)
+  - `telegram-get-my-boosts` — list boost slots assigned by your account
+  - `telegram-get-boosts-status` — boost status for a channel/supergroup
+  - `telegram-get-boosts-list` — list boosters for a channel (admin)
+  - `telegram-get-business-chat-links` — list your Telegram Business chat links
+- **Phase 4 opt-in (env-gated, 6 tools)** — registered only when the corresponding flag is set:
+  - `MCP_TELEGRAM_ENABLE_GROUP_CALLS=1` → `telegram-get-group-call`, `telegram-get-group-call-participants`
+  - `MCP_TELEGRAM_ENABLE_STARS=1` → `telegram-get-stars-status`, `telegram-get-stars-transactions`
+  - `MCP_TELEGRAM_ENABLE_QUICK_REPLIES=1` → `telegram-get-quick-replies`, `telegram-get-quick-reply-messages`
 
 ## 1.25.0 — 2026-04-20 {#v1-25-0}
 
-### 新增
-- **定时消息** — `telegram-get-scheduled`、`telegram-delete-scheduled`
-- **话题与回复** — `telegram-get-replies`（频道帖子评论）
-- **消息链接** — `telegram-get-message-link` 返回公开的 t.me URL
-- **提及与未读回应** — `telegram-get-unread-mentions`、`telegram-get-unread-reactions`
-- **翻译** — `telegram-translate-message`（需要 Telegram Premium）
-- **输入状态** — `telegram-send-typing`
-- **会话管理** — `telegram-archive-chat`、`telegram-pin-chat`、`telegram-mark-dialog-unread`
-- **草稿** — `telegram-save-draft`、`telegram-get-drafts`、`telegram-clear-drafts`
-- **Saved Messages 文件夹** — `telegram-get-saved-dialogs`
-- **管理员日志** — `telegram-get-admin-log`
-- **回应目录** — `telegram-set-default-reaction`、`telegram-get-top-reactions`、`telegram-get-recent-reactions`
-- **聊天权限与慢速模式** — `telegram-set-chat-permissions`、`telegram-set-slow-mode`
-- **论坛话题 CRUD** — `telegram-create-topic`、`telegram-edit-topic`、`telegram-delete-topic`
-- **网页预览** — `telegram-get-web-preview`
+### Added
 
-### 修复
-- `telegram-set-chat-permissions` 现在会与当前的 `defaultBannedRights` 合并 — 未指定的标志保留原值，而非被静默清除
-- `telegram-clear-drafts` 需要提供 `chatId` 或 `confirmAllChats: true` 才能清除所有聊天的草稿
-- `telegram-get-unread-mentions` / `-reactions` 标注为 `WRITE` — 调用会在服务端将列出的项目标为已读
-- `telegram-translate-message` 标注为 `WRITE`；`toLang` 经过校验，`messageIds` 上限 1–100
-- `telegram-delete-scheduled` 将 `messageIds` 限制为 1–100 个正整数
-- `telegram-set-default-reaction` 校验 emoji 长度（1–8 个字符）
-- `telegram-get-web-preview` 拒绝非 `http(s)` URL，防止被用作 SSRF 代理
-- `telegram-send-typing` 对非 `cancel` 动作按聊天每 10 秒限流一次
-- `telegram-get-saved-dialogs` 不再返回始终为零的 `unreadCount` 字段
-- `telegram-create-topic` 从 `UpdateNewChannelMessage` 读取新话题 ID（权威来源），两者都不可用时明确抛错
-- `telegram-save-draft` 在文本为空时丢弃 `replyTo`，避免清空草稿时触发 `MESSAGE_EMPTY`
+- **Scheduled messages** — `telegram-get-scheduled`, `telegram-delete-scheduled`
+- **Threads & replies** — `telegram-get-replies` for channel post comments
+- **Message links** — `telegram-get-message-link` returns public t.me URL for a message
+- **Mentions & unread reactions** — `telegram-get-unread-mentions`, `telegram-get-unread-reactions`
+- **Translate** — `telegram-translate-message` (requires Telegram Premium)
+- **Typing indicator** — `telegram-send-typing` with configurable action
+- **Dialog management** — `telegram-archive-chat`, `telegram-pin-chat`, `telegram-mark-dialog-unread`
+- **Drafts** — `telegram-save-draft`, `telegram-get-drafts`, `telegram-clear-drafts`
+- **Saved Messages dialogs** — `telegram-get-saved-dialogs` for the new per-peer Saved Messages folders
+- **Admin log** — `telegram-get-admin-log` for channel/supergroup moderation history
+- **Reactions catalog** — `telegram-set-default-reaction`, `telegram-get-top-reactions`, `telegram-get-recent-reactions`
+- **Chat permissions** — `telegram-set-chat-permissions` for default banned rights
+- **Slow mode** — `telegram-set-slow-mode` for supergroups
+- **Forum topics CRUD** — `telegram-create-topic`, `telegram-edit-topic`, `telegram-delete-topic`
+- **Web page preview** — `telegram-get-web-preview` to inspect link previews before sending
 
-## v1.24.1 <Badge type="tip" text="最新" /> {#v1.24.1}
-**2026-04-20**
+### Fixed
 
-### 变更
-- 依赖升级到最新版本：`@modelcontextprotocol/sdk` 1.29.0、`dotenv` 17.4.2、`@biomejs/biome` 2.4.12、`typescript` 6.0.3、`@types/node` 25.6.0
+- `telegram-set-chat-permissions` now merges with the chat's current `defaultBannedRights` — omitted flags keep their current state instead of being silently cleared
+- `telegram-clear-drafts` requires `chatId` (single-chat) or `confirmAllChats: true` to wipe drafts account-wide, preventing accidental loss of all drafts in one call
+- `telegram-get-unread-mentions` and `telegram-get-unread-reactions` are now annotated as `WRITE` — they mark the listed items as read on the server
+- `telegram-translate-message` is now annotated as `WRITE` (consumes Premium translate quota); `toLang` is validated against an ISO-639 / locale pattern and `messageIds` is capped at 1–100 positive integers
+- `telegram-delete-scheduled` caps `messageIds` at 1–100 positive integers
+- `telegram-set-default-reaction` validates `emoji` length (1–8 characters)
+- `telegram-get-web-preview` rejects non-`http(s)` URLs, preventing use as an SSRF proxy
+- `telegram-send-typing` throttles non-`cancel` actions to once per 10 seconds per chat
+- `telegram-get-saved-dialogs` no longer returns a hard-coded `unreadCount: 0`
+- `telegram-create-topic` now reads the new topic ID from `UpdateNewChannelMessage` (authoritative) and fails loudly if neither source is available
+- `telegram-save-draft` drops `replyTo` when the draft text is empty, avoiding `MESSAGE_EMPTY` errors when clearing drafts
+- Removed unused `chatMap` build in `getAdminLog`
 
-## v1.24.0 {#v1.24.0}
-**2026-04-06**
+## 1.24.1 — 2026-04-20 {#v1-24-1}
 
-### 新增
-- **贴纸工具** — 5 个新工具（共 59 个）：`telegram-get-sticker-set`、`telegram-search-sticker-sets`、`telegram-get-installed-stickers`、`telegram-send-sticker`、`telegram-get-recent-stickers`
-- **预编译二进制文件** — 零依赖独立可执行文件，支持 Linux (x64/ARM64)、macOS (x64/ARM64)、Windows (x64)
-- **文档网站** — 基于 VitePress，支持多语言（English、Русский、中文）
+### Changed
 
-## v1.23.0 {#v1.23.0}
-**2026-04-05**
+- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
 
-### 新增
-- 11 个新工具（共 22 个）：回应、编辑/删除/转发消息、标记已读、对话、聊天信息、发送文件、添加联系人、创建投票、管理话题
-- 账户管理：会话、隐私、自动删除、个人资料
+## 1.24.0 — 2026-04-06 {#v1-24-0}
 
-## v1.22.0 {#v1.22.0}
-**2026-04-01**
+### Added
 
-### 新增
-- 输入指示器（10 种操作类型）
-- 按 ID 获取消息
+- **Sticker tools** — 5 new tools (59 total): `telegram-get-sticker-set`, `telegram-search-sticker-sets`, `telegram-get-installed-stickers`, `telegram-send-sticker`, `telegram-get-recent-stickers`
+- **Documentation site** — VitePress-based docs at overpod.github.io/mcp-telegram with i18n (English, Russian, Chinese)
 
-## v1.21.0 — v1.20.0 {#v1.21.0}
-**2026-03-31 — 2026-04-01**
+## 1.23.0 — 2026-04-05 {#v1-23-0}
 
-### 新增
-- GramJS 客户端公开访问器
-- 自动限流与 FLOOD_WAIT 处理
-- `send-message` 返回 `messageId`
+### Added
 
-## v1.19.0 {#v1.19.0}
-**2026-03-30**
+- 11 new tools (22 total): `telegram-send-reaction`, `telegram-edit-message`, `telegram-delete-message`, `telegram-forward-message`, `telegram-mark-as-read`, `telegram-get-dialogs`, `telegram-get-chat-info`, `telegram-send-file`, `telegram-add-contact`, `telegram-create-poll`, `telegram-manage-topics`
+- Account management tools: `telegram-get-sessions`, `telegram-terminate-session`, `telegram-set-privacy`, `telegram-set-auto-delete`, `telegram-update-profile`
+- Better entity resolution for channels and supergroups
 
-### 新增
-- Docker 支持
-- 非阻塞启动
-- 本地 QR 码备用方案
+## 1.22.0 — 2026-04-01 {#v1-22-0}
 
-## v1.18.0 — v1.14.0 {#v1.18.0}
-**2026-03-28**
+### Added
 
-### 新增
-- 群组管理：邀请、踢出、封禁、编辑
-- 创建群组
-- SOCKS5 和 MTProxy 支持
-- 按显示名称解析聊天
+- `TelegramService.setTyping(chatId, action?)` — send typing indicators with 10 action types: `typing`, `cancel`, `record_video`, `upload_video`, `record_audio`, `upload_audio`, `upload_photo`, `upload_document`, `choose_sticker`, `game_play` (#17)
+- `TelegramService.getMessageById(chatId, messageId)` — fetch a single message by ID, returns formatted message object or `null`. Uses GramJS `ids` filter for exact lookup (#17)
 
-## v1.13.0 — v1.9.0 {#v1.13.0}
-**2026-03-18 — 2026-03-26**
+## 1.21.0 — 2026-04-01 {#v1-21-0}
 
-### 新增/变更
-- 工具重构为模块化文件
-- 完整回应支持
-- 论坛话题
-- 多账户支持
-- 安全会话存储
+### Added
 
-## v1.8.0 — v1.5.0 {#v1.8.0}
-**2026-03-16 — 2026-03-18**
+- `TelegramService.getClient()` — public accessor for the underlying GramJS `TelegramClient` instance, enabling event handlers like `NewMessage` for real-time listeners (#17)
 
-### 新增
-- 联系人管理、屏蔽、举报
-- 回应、定时消息、投票
+## 1.20.0 — 2026-03-31 {#v1-20-0}
 
-## v1.4.0 — v1.1.0 {#v1.4.0}
-**2026-03-11 — 2026-03-15**
+### Added
 
-### 新增
-- Glama.ai 和 Smithery 目录
-- 媒体、联系人、个人资料、分页、转发、删除
+- **Rate limiting & retry** — automatic FLOOD_WAIT handling, network error recovery with exponential backoff (`src/rate-limiter.ts`)
+- `send-message` now returns `messageId` in the response (`Message sent to @user [#12345]`), enabling send → edit workflows (closes #16)
+- Rate limiter unit tests (7 tests in `src/__tests__/rate-limiter.test.ts`)
 
-## v1.0.0 {#v1.0.0}
-**2026-03-10**
+### Changed
 
-### 🎉 首次发布
-- Telegram userbot MCP 服务器
-- 消息读取和发送
-- 二维码登录
-- GramJS/MTProto 集成
+- `sendMessage()` return type changed from `void` to `Api.Message | Api.UpdateShortSentMessage | undefined`
+- Write methods (`sendMessage`, `sendFile`, `editMessage`, `deleteMessages`) are now rate-limited with automatic retry on transient errors
+
+## 1.19.0 — 2026-03-30 {#v1-19-0}
+
+### Added
+
+- Docker support for containerized deployment
+- Non-blocking startup behavior
+- Local QR code fallback for authentication
+- Automated test infrastructure with Node.js test runner
+- CI workflow to publish Docker images to GitHub Container Registry
+
+## 1.18.0 — 2026-03-28 {#v1-18-0}
+
+### Added
+
+- New `telegram-get-my-role` tool to check user's role in a chat
+- Role information in `telegram-get-chat-members` results
+
+## 1.17.0 — 2026-03-28 {#v1-17-0}
+
+### Added
+
+- Chat resolution by display name (not just ID or username)
+
+### Changed
+
+- Updated documentation to replace static tool list with auto-discovery note
+- Improved project structure documentation
+
+## 1.16.0 — 2026-03-28 {#v1-16-0}
+
+### Added
+
+- Group management tools: invite, kick, ban, edit, leave
+- Admin management capabilities
+
+## 1.15.0 — 2026-03-28 {#v1-15-0}
+
+### Added
+
+- `telegram-create-group` tool for creating new groups
+
+### Fixed
+
+- Documented `AUTH_KEY_DUPLICATED` error handling
+
+## 1.14.0 — 2026-03-28 {#v1-14-0}
+
+### Added
+
+- SOCKS5 proxy support for Telegram connections
+- MTProxy support for Telegram connections
+
+### Changed
+
+- Added proxy documentation to README
+
+## 1.13.0 — 2026-03-26 {#v1-13-0}
+
+### Changed
+
+- Refactored tools into modular files organized by category
+
+## 1.12.0 — 2026-03-26 {#v1-12-0}
+
+### Changed
+
+- Migrated to `registerTool()` API with tool annotations
+
+## 1.11.1 — 2026-03-25 {#v1-11-1}
+
+### Fixed
+
+- Sanitized unpaired UTF-16 surrogates in tool responses
+
+### Changed
+
+- Upgraded TypeScript to 6.0
+- Updated README with missing tools
+
+## 1.11.0 — 2026-03-23 {#v1-11-0}
+
+### Added
+
+- Full reactions support: read, send multiple reactions, get detailed info
+
+### Changed
+
+- Included message ID in all message-reading tool outputs
+
+## 1.10.1 — 2026-03-22 {#v1-10-1}
+
+### Fixed
+
+- Message ID now included in all message-reading tool outputs
+
+## 1.10.0 — 2026-03-20 {#v1-10-0}
+
+### Added
+
+- Enhanced `telegram-get-profile` with birthday, business, and premium data
+- New `telegram-get-profile-photo` tool
+- Global message search capability
+- Enriched chat search results
+
+## 1.9.0 — 2026-03-18 {#v1-9-0}
+
+### Added
+
+- Forum Topics support
+- Per-topic unread count for forum groups
+- Secure session storage with configurable path
+- Multiple accounts support
+
+### Fixed
+
+- Per-topic unread sum calculation for forum groups
+
+### Changed
+
+- Updated session path and security documentation
+- Upgraded GitHub Actions to v6
+- Replaced Node 20 with Node 24 in CI
+
+## 1.8.1 — 2026-03-19 {#v1-8-1}
+
+### Fixed
+
+- Redirected console.log to stderr to prevent MCP JSON-RPC corruption
+
+## 1.8.0 — 2026-03-18 {#v1-8-0}
+
+### Added
+
+- Secure session storage with configurable path via SESSION_PATH environment variable
+
+### Changed
+
+- Updated session path and security information in README
+
+## 1.7.0 — 2026-03-16 {#v1-7-0}
+
+### Added
+
+- CI workflow to publish to GitHub Packages alongside npm
+- Manual workflow dispatch trigger for publishing
+
+## 1.6.0 — 2026-03-16 {#v1-6-0}
+
+### Added
+
+- Contact request management
+- Block/unblock users
+- Report spam functionality
+- Add contact tool
+- ChatGPT to list of supported clients
+
+### Changed
+
+- Removed hardcoded tool counts from README and package.json
+
+## 1.5.0 — 2026-03-16 {#v1-5-0}
+
+### Added
+
+- Reactions support
+- Scheduled messages
+- Polls creation and management
+- `telegram-join-chat` tool for joining groups and channels
+
+### Changed
+
+- Updated README with new tool documentation
+- Increased tool count to 24
+
+## 1.4.0 — 2026-03-15 {#v1-4-0}
+
+### Added
+
+- Glama.ai MCP catalog verification (glama.json)
+- Smithery MCP catalog listing (smithery.yaml)
+- Demo GIF and badges to README
+- Hosted version link
+
+### Fixed
+
+- Removed PNG file save from CLI QR login
+
+### Changed
+
+- Updated README with Glama MCP server badge
+
+## 1.3.1 — 2026-03-12 {#v1-3-1}
+
+### Fixed
+
+- Use `destroy()` instead of `disconnect()` to stop GramJS update loop
+- Adopt QR login client directly instead of destroy+reconnect flow
+- Destroy GramJS client in `logOut()` and `startQrLogin()` to stop update loop
+
+## 1.3.0 — 2026-03-12 {#v1-3-0}
+
+### Added
+
+- `logOut()` method for complete Telegram session termination
+
+## 1.2.0 — 2026-03-11 {#v1-2-0}
+
+### Added
+
+- `downloadMediaAsBuffer` for serverless media download
+- Library exports and declaration types
+- Date filters for messages
+- Comprehensive README for v1.0
+
+### Fixed
+
+- MIME type detection from magic bytes in `downloadMediaAsBuffer`
+- Made `saveSession` resilient to file write errors in Docker
+
+### Changed
+
+- Use `GetFullChannel`/`GetFullChat` for complete chat information
+- Improved `telegram-login` for Claude Desktop users
+- Added npm publishing support and GitHub Actions CI/CD
+
+## 1.1.0 — 2026-03-11 {#v1-1-0}
+
+### Added
+
+- Contact management tools
+- Chat members listing
+- User profile retrieval
+- Chat type filter
+- Media tools (send, download, get info)
+- Pin/unpin messages
+- Markdown support
+- Media information in messages
+- Unread counts
+- Mark messages as read
+- Forward messages
+- Edit messages
+- Delete messages
+- Detailed chat information
+- Pagination support
+
+## 1.0.0 — 2026-03-10 {#v1-0-0}
+
+### Added
+
+- Initial release: MCP server for Telegram userbot
+- Basic message reading and sending
+- Chat listing
+- Authentication via phone number and QR code
+- Session persistence
+- GramJS/MTProto integration

--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
     "test": "tsx --test 'src/**/*.test.ts'",
     "test:watch": "tsx --test --watch 'src/**/*.test.ts'",
     "test:coverage": "c8 --all --src src --exclude 'src/**/*.test.ts' --reporter=text tsx --test 'src/**/*.test.ts'",
+    "gen:changelog": "tsx scripts/gen-changelog-docs.ts",
+    "gen:changelog:check": "tsx scripts/gen-changelog-docs.ts --check",
+    "predocs:dev": "npm run gen:changelog",
     "docs:dev": "vitepress dev docs",
+    "predocs:build": "npm run gen:changelog",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },

--- a/scripts/gen-changelog-docs.ts
+++ b/scripts/gen-changelog-docs.ts
@@ -1,0 +1,231 @@
+/**
+ * Generates the VitePress changelog pages from the single source of truth,
+ * CHANGELOG.md (maintained by release-please).
+ *
+ * Writes docs/changelog.md (English) plus localized docs/ru/changelog.md and
+ * docs/zh/changelog.md — header/intro are localized, version entries stay in
+ * English (CHANGELOG.md is English-only; freshness beats partial translation).
+ *
+ * Run with no args to write the files; pass --check to fail (exit 1) when the
+ * generated output differs from what's on disk — used in CI to catch a stale
+ * commit. Invoked from prebuild of the docs (`predocs:build`).
+ *
+ * No external deps: runs under tsx (dev) and `node` (CI) against the repo root.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+
+interface Entry {
+  version: string;
+  date: string;
+  /** Section name (Added/Fixed/Changed/...) → list of cleaned bullet lines. */
+  sections: Map<string, string[]>;
+}
+
+/** Strip release-please's inline commit/PR links, leaving human-readable prose. */
+function cleanLine(line: string): string {
+  return (
+    line
+      // normalize bullet marker `* ` → `- ` (release-please uses `*`, docs use `-`)
+      .replace(/^(\s*)\*\s+/, "$1- ")
+      // ([abc1234](https://github.com/.../commit/...)) — drop entirely
+      .replace(/\s*\(\[[0-9a-f]{6,}\]\([^)]*\)\)/g, "")
+      // ([#49](https://github.com/.../issues/49)) → (#49)
+      .replace(/\(\[(#\d+)\]\([^)]*\)\)/g, "($1)")
+      // bare [text](url) commit/issue refs left over → text
+      .replace(/\[([^\]]+)\]\((https?:\/\/[^)]*)\)/g, "$1")
+      .trimEnd()
+  );
+}
+
+/** Conventional-commit scopes that carry no user-facing signal. */
+const NOISE_SCOPE = /^\s*-\s+\*\*(deps|build|ci|chore|docs|test|style|refactor)(\([^)]*\))?:\*\*/i;
+
+/** A single bullet is noise if it's a noise-scoped commit or a plain deps bump. */
+function isNoiseBullet(line: string): boolean {
+  if (NOISE_SCOPE.test(line)) return true;
+  return /^\s*-\s+.*\b(dependenc|devdep|bump|lockfile|biome|tsx|npm audit)/i.test(line);
+}
+
+/** Parse CHANGELOG.md into version entries (newest first, as written). */
+function parseChangelog(md: string): Entry[] {
+  const lines = md.split("\n");
+  const entries: Entry[] = [];
+  let cur: Entry | null = null;
+  let curSection: string | null = null;
+
+  // Matches all three header shapes release-please / hand edits produce.
+  // The date is the LAST date token on the line — anchor on $ so the compare
+  // URL's embedded version numbers (…compare/v1.37.1...v1.38.0…) can't be
+  // mistaken for it:
+  //   ## [1.38.1](https://…compare…) (2026-06-10)
+  //   ## [1.37.0] — 2026-06-04
+  //   ## [1.23.0] - 2026-04-05
+  const header = /^##\s+\[(\d+\.\d+\.\d+)\].*?(\d{4}-\d{2}-\d{2})\)?\s*$/;
+
+  for (const raw of lines) {
+    const h = raw.match(header);
+    if (h) {
+      cur = { version: h[1], date: h[2], sections: new Map() };
+      entries.push(cur);
+      curSection = null;
+      continue;
+    }
+    if (!cur) continue;
+
+    const sec = raw.match(/^###\s+(.+?)\s*$/);
+    if (sec) {
+      curSection = sec[1];
+      if (!cur.sections.has(curSection)) cur.sections.set(curSection, []);
+      continue;
+    }
+
+    // Bullet line (top-level or nested) under the current section.
+    if (/^\s*[-*]\s+/.test(raw) && curSection) {
+      cur.sections.get(curSection)?.push(cleanLine(raw));
+    } else if (raw.trim() && curSection && /^\s{2,}/.test(raw)) {
+      // continuation / nested non-bullet line — keep as-is (cleaned)
+      cur.sections.get(curSection)?.push(cleanLine(raw));
+    }
+  }
+  return entries;
+}
+
+/** Sections that carry no user-facing signal — dropped from mixed releases. */
+const NOISE_SECTIONS = new Set(["Documentation", "Build", "CI", "Chores", "Miscellaneous Chores"]);
+
+/** Non-noise bullets in a section, keyed by section name. Empty → nothing to show. */
+function signalSections(e: Entry): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const [name, items] of e.sections) {
+    if (NOISE_SECTIONS.has(name)) continue;
+    const keep = items.filter((i) => i.trim() && !isNoiseBullet(i));
+    if (keep.length > 0) out.set(name, keep);
+  }
+  return out;
+}
+
+/** A version is "noise-only" if no section has any user-facing bullet left. */
+function isNoiseOnly(e: Entry): boolean {
+  return signalSections(e).size === 0;
+}
+
+function anchor(version: string): string {
+  return `v${version.replace(/\./g, "-")}`;
+}
+
+function renderEntry(e: Entry, latest: boolean): string {
+  const badge = latest ? ' <Badge type="tip" text="latest" />' : "";
+  const out: string[] = [`## ${e.version} — ${e.date}${badge} {#${anchor(e.version)}}`, ""];
+
+  if (isNoiseOnly(e)) {
+    // Collapse pure deps/ci/docs releases into a single neutral line.
+    out.push(
+      "### Changed",
+      "",
+      "- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).",
+      "",
+    );
+    return out.join("\n");
+  }
+
+  // Mixed release: emit only sections with user-facing bullets (noise filtered out).
+  for (const [name, items] of signalSections(e)) {
+    out.push(`### ${name}`, "");
+    for (const i of items) out.push(i);
+    out.push("");
+  }
+  return out.join("\n");
+}
+
+interface Locale {
+  /** Output path relative to repo root. */
+  path: string;
+  title: string;
+  currentLabel: string;
+  intro: string;
+}
+
+const LOCALES: Locale[] = [
+  {
+    path: "docs/changelog.md",
+    title: "Changelog",
+    currentLabel: "Current version",
+    intro:
+      "All notable changes to MCP Telegram. For the full diff between versions, see [GitHub Releases](https://github.com/mcp-telegram/mcp-telegram/releases).",
+  },
+  {
+    path: "docs/ru/changelog.md",
+    title: "Список изменений",
+    currentLabel: "Текущая версия",
+    intro:
+      "Все заметные изменения в MCP Telegram. Полное сравнение версий — на [GitHub Releases](https://github.com/mcp-telegram/mcp-telegram/releases). Записи приведены на английском (как в исходном CHANGELOG).",
+  },
+  {
+    path: "docs/zh/changelog.md",
+    title: "更新日志",
+    currentLabel: "当前版本",
+    intro:
+      "MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](https://github.com/mcp-telegram/mcp-telegram/releases)。条目以英文显示（与源 CHANGELOG 一致）。",
+  },
+];
+
+function renderPage(loc: Locale, entries: Entry[], pkgVersion: string): string {
+  const body = entries.map((e, idx) => renderEntry(e, idx === 0)).join("\n");
+  return [
+    `# ${loc.title}`,
+    "",
+    `<VersionBadge version="${pkgVersion}" /> ${loc.currentLabel}`,
+    "",
+    loc.intro,
+    "",
+    "<!-- Generated from CHANGELOG.md by scripts/gen-changelog-docs.ts. Do not edit by hand. -->",
+    "",
+    body.trimEnd(),
+    "",
+  ].join("\n");
+}
+
+function main() {
+  const check = process.argv.includes("--check");
+  const changelog = readFileSync(join(ROOT, "CHANGELOG.md"), "utf8");
+  const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as { version: string };
+  const entries = parseChangelog(changelog);
+
+  if (entries.length === 0) {
+    console.error("gen-changelog-docs: parsed 0 versions from CHANGELOG.md — refusing to write empty pages.");
+    process.exit(1);
+  }
+
+  let drift = false;
+  for (const loc of LOCALES) {
+    const next = renderPage(loc, entries, pkg.version);
+    const abs = join(ROOT, loc.path);
+    const prev = (() => {
+      try {
+        return readFileSync(abs, "utf8");
+      } catch {
+        return "";
+      }
+    })();
+    if (next !== prev) {
+      drift = true;
+      if (check) {
+        console.error(`gen-changelog-docs: ${loc.path} is stale. Run \`npm run gen:changelog\` and commit.`);
+      } else {
+        writeFileSync(abs, next);
+        console.log(`gen-changelog-docs: wrote ${loc.path} (${entries.length} versions)`);
+      }
+    }
+  }
+
+  if (check && drift) process.exit(1);
+  if (!check && !drift) console.log("gen-changelog-docs: all changelog pages already up to date.");
+}
+
+main();


### PR DESCRIPTION
## Problem

The docs-site changelog (`docs/changelog.md` + `ru`/`zh`) was hand-maintained and had drifted **21 versions behind** — it showed `1.26.0` as "current version" while the package shipped `1.38.1`, and carried a stale `latest` badge on `v1.24.1`. README also had a hardcoded `80+ tools` count, an outdated MCP SDK badge (1.27), and no mention of features shipped in 1.33–1.38.

## Fix: generate, don't hand-write

`scripts/gen-changelog-docs.ts` reads `CHANGELOG.md` (the release-please source of truth) and emits all three locale pages:
- strips inline commit/PR links → readable prose
- collapses deps/ci/docs-only releases into one neutral line
- localized header/intro per locale; version entries stay English (CHANGELOG is English-only — freshness over partial translation)
- `<VersionBadge>` reads the live package version; `latest` badge on the newest release

**Wiring:**
- `predocs:build` runs it → the deployed site is always fresh
- `gen:changelog:check` CI gate → a stale commit fails the PR (negative-tested: exits 1 on drift, 0 when in sync)
- Deploy Docs now runs `docs:build` (regenerates on deploy); its `paths:` filter now includes `CHANGELOG.md` + the generator

## README refresh

- drop hardcoded `80+ tools` (count goes stale — project rule)
- MCP SDK badge `1.27` → `1.29` (matches `package.json` `^1.29.0`)
- add Features + Tools-table coverage for **chat folders** & **global privacy** (v1.33.0), **Star gifts** (v1.34.0, opt-in `MCP_TELEGRAM_ENABLE_STARS`), and the **shared daemon** (v1.38.0)

## Verification

- Generator: deterministic, idempotent, parses all 3 CHANGELOG header formats (incl. the compare-URL form). 49 versions emitted, 1.0.0 → 1.38.1.
- Every added tool name, version tag, and the env gate fact-checked against `src/tools/*.ts` and `CHANGELOG.md` (self-review pass, nothing fabricated).
- `typecheck` / `lint` / 513 tests / `docs:build` / `gen:changelog:check` all green.

## Known follow-up (out of scope, source-of-truth gap)

`CHANGELOG.md` is **missing v1.27.0 / v1.27.1 / v1.28.0 / v1.28.1** — those tags + GitHub Releases exist, but the entries aren't in `CHANGELOG.md` (lost in an earlier edit). Since the generator reads CHANGELOG, the gap propagates to docs. Restoring those 4 entries needs their real notes — left for a follow-up so this PR doesn't invent content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)