### PR TITLE
docs: backfill v1.27–v1.28 in CHANGELOG; bump Pages actions off Node 20

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,18 +25,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       # docs:build runs predocs:build (gen:changelog) first, so the deployed
       # site always reflects CHANGELOG.md even if the committed pages lag.
       - run: npm run docs:build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -48,4 +48,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,63 @@ Tests: 490/490 pass.
 - **Album mixed photo+video** — GramJS accepts mixed arrays via extension-based detection, but this is not covered by tests; recommend uniform media type per album until a live-test checkpoint confirms.
 - **Album flood control** — a 10-item album fans out 10 `messages.UploadMedia` calls inside one rate-limit slot; under heavy contention the later items may still hit `FLOOD_WAIT`. Rate limiter retries apply.
 
+## [1.28.1] - 2026-04-22
+
+### Added
+- **`telegram-logout`** — new tool (Auth category, annotated `DESTRUCTIVE`). Fully logs out: calls `auth.LogOut` on Telegram servers (session disappears from Settings → Devices), destroys the GramJS client, deletes the local session file, and clears in-memory state. Takes no parameters. Handles every state cleanly — connected (server revoke + local wipe), disconnected with a session file (local wipe only, with a notice), no session (`fail` "Not logged in"), and `auth.LogOut` throwing (local wipe still happens, with a "check Settings → Devices manually" hint).
+
+### Changed
+- **`TelegramService.logOut()` hardened** — server-revoke and client-destroy are now split: a successful `auth.LogOut` returns `true` even if `client.destroy()` throws (previously misreported "not confirmed"). The local wipe is verified post-unlink and throws if the session file survives (e.g. read-only Docker mount), instead of falsely reporting success. File removal now always runs even when server-revoke fails (network error, `AUTH_KEY_UNREGISTERED`).
+- **Master cancels active QR login on logout** — a `telegram-logout` request now aborts an in-progress QR login flow before acquiring `globalLock`, instead of queuing behind it for up to 5 minutes.
+
+### Testing
+- 322 unit tests (+10 vs v1.28.0) — `hasLocalSession()`, `logOut()` edge cases (connected / disconnected±file / network error / idempotency / FS-throws / destroy-throws-but-revoke-succeeds), and a Master integration test that logout aborts an active login over a real unix socket.
+
+### Notes & known limitations
+- In a 3-client FIFO scenario (A holds the lock via login, B queues a tool call, C requests logout), logout correctly aborts A, but B still runs before logout because FIFO order is preserved. A priority-aware queue is deferred.
+
+## [1.28.0] - 2026-04-22
+
+### Added
+- **QR login through the IPC daemon** — `mcp-telegram login` now flows through the Master daemon over IPC instead of running as a separate process. The new session reaches the Master's memory immediately, with no editor restart. This fixes the "relogin via `mcp-telegram login`" flavor of `AUTH_KEY_DUPLICATED`/`AUTH_KEY_UNREGISTERED`, where the standalone login wrote a fresh session to disk but the running Master kept the old, now-invalidated auth key in memory and then wiped the just-created session on the next tool call.
+  - `IpcClient.loginFlow(onQr)` — streams QR frames as they refresh (~every 10s).
+  - `handleLoginStart` on Master — runs `startQrLogin` on the shared `TelegramService`.
+  - `GlobalLock` (FIFO mutex) — serializes tool calls with the login flow so other clients queue instead of hitting a stale client mid-relogin.
+  - `AbortController` — `socket.on("close")` aborts the QR loop if the CLI is interrupted (Ctrl+C / terminal closed); `globalLock` releases immediately instead of blocking tool calls for up to 5 minutes.
+  - Session swap now saves to disk first, then adopts in memory and destroys the previous client — prevents orphan Telegram connections accumulating per relogin.
+  - Standalone fallback kept — if no Master is running, `mcp-telegram login` works exactly as before.
+
+### Changed
+- **BREAKING (internal IPC only): IPC protocol is now a discriminated union** with a required `type` tag (`tool` / `tool_response` / `login_start` / `login_qr` / `login_done`). A new 1.28.0 client and an older 1.27.x Master cannot talk — restart your editor / Claude Code after upgrading so the Master daemon is replaced. No public API or invocation change. (Parent-crash detection already kills stale Masters in most cases, so this is transparent for VS Code / Claude Desktop users.)
+
+### Fixed
+- Socket errors on Master now log to stderr instead of being silently dropped.
+- `client.destroy()` in abort branches wrapped in try/catch — guarantees the "QR login aborted" message even if Telegram destroy throws.
+- QR render errors (`QRCode.toString` failure) logged to stderr instead of silently dropped.
+
+### Testing
+- 312 unit tests (was 288) — new suites for `GlobalLock` (FIFO ordering, double-release safety), Master login (QR URL forwarding, abort on socket close), child-process integration via tsx, `IpcClient.loginFlow`, and IPC discriminated-union / legacy-protocol rejection.
+
+## [1.27.1] - 2026-04-22
+
+### Changed
+- Patch release — no new tools, no API changes; pure code-quality and test-coverage work. Refactored `telegram-client.ts` re-exports (eliminates 2 Biome `noUnusedImports` false-positives), replaced unsafe `(e as Error).message` casts with `e instanceof Error` guards in the stats methods, and added `McpRegisteredTool` / `McpServerInternal` types to `ipc-protocol.ts` as a single source of truth (previously duplicated across master.ts and client.ts).
+
+### Testing
+- 286 unit tests (+25 vs v1.27.0) — new branch coverage for `wireIpcProxies` (incl. a safety test that the original `TelegramService` handler is never called after wiring), the rate limiter (`throwOnFloodWait`, retry exhaustion, 5xx, GramJS `errorMessage`), and the IPC protocol parser (malformed JSON, blank lines, partial-line buffering, multiple messages per chunk). `rate-limiter.ts` reached 100% statements.
+
+## [1.27.0] - 2026-04-21
+
+### Added
+- **Master/Client IPC daemon — fixes `AUTH_KEY_DUPLICATED` across concurrent Claude sessions.** Opening multiple Claude sessions used to spawn separate `mcp-telegram` processes that each connected to Telegram with the same session, which Telegram rejected as a duplicate. Now the first process to start becomes the **Master** (holds the single GramJS connection, listens on a Unix socket at `~/.mcp-telegram/daemon.sock`) and every subsequent process becomes a thin **Client** that proxies tool calls to the Master over the socket — one connection, one auth key, no duplicates. Zero config change; same invocation.
+  - New files: `src/lock.ts` (atomic `O_EXCL` PID lockfile + stale-lock detection via `kill -0`), `src/ipc-protocol.ts` (IPC message types + newline-delimited JSON parser), `src/master.ts` (Unix socket server, sequential queue dispatcher), `src/client.ts` (`IpcClient` with timeout + retry, handler proxy).
+  - Security: socket file is `chmod 0o600` (owner-only); the session string never leaves the Master process.
+
+### Fixed
+- Atomic lock via `O_EXCL` prevents a race when multiple sessions start simultaneously; stale socket from a previous crash is removed before `listen` (no `EADDRINUSE`).
+- One-shot connect timeout (not idle) so live connections survive inactivity; 30s IPC call timeout so a stuck Master surfaces a clean error instead of hanging.
+- Sequential `drainQueue()` loop for correct concurrent-request handling; `.catch()` on auto-connect to avoid `unhandledRejection`; idempotent cleanup (`cleanedUp` flag) so SIGINT/SIGTERM don't double-release.
+
 ## [1.26.0] - 2026-04-20
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,6 +53,7 @@ All notable changes to MCP Telegram. For the full diff between versions, see [Gi
 
 ### Changed
 
+  - `biome.json` schema bumped to 2.4.15 via `biome migrate --write`
   - `hono` 4.12.9 → 4.12.18 (CSS injection in JSX SSR, JWT NumericDate, Cache `Vary`, etc.)
   - `fast-uri` 3.1.0 → 3.1.2 (host confusion + path traversal)
   - `ip-address` 10.1.0 → 10.2.0 (Address6 HTML XSS)
@@ -262,6 +263,7 @@ All notable changes to MCP Telegram. For the full diff between versions, see [Gi
 ### Security
 
 - `quoteText` without `replyTo` now raises a clear error instead of silently dropping the quote.
+- GramJS private `_parseMessageText` usage in the quoteText/effect raw path is feature-detected; future GramJS bumps surface a clear "version incompatible" error instead of crashing.
 - `effect` ID regex tightened to `^\d{1,19}$` (Int64-safe range).
 
 ### Testing
@@ -277,6 +279,74 @@ All notable changes to MCP Telegram. For the full diff between versions, see [Gi
 - **`telegram-send-voice.duration` removed vs. initial design** — GramJS auto-detects duration from the audio file; letting the AI override it caused the Telegram UI to display wrong playback times.
 - **Album mixed photo+video** — GramJS accepts mixed arrays via extension-based detection, but this is not covered by tests; recommend uniform media type per album until a live-test checkpoint confirms.
 - **Album flood control** — a 10-item album fans out 10 `messages.UploadMedia` calls inside one rate-limit slot; under heavy contention the later items may still hit `FLOOD_WAIT`. Rate limiter retries apply.
+
+## 1.28.1 — 2026-04-22 {#v1-28-1}
+
+### Added
+
+- **`telegram-logout`** — new tool (Auth category, annotated `DESTRUCTIVE`). Fully logs out: calls `auth.LogOut` on Telegram servers (session disappears from Settings → Devices), destroys the GramJS client, deletes the local session file, and clears in-memory state. Takes no parameters. Handles every state cleanly — connected (server revoke + local wipe), disconnected with a session file (local wipe only, with a notice), no session (`fail` "Not logged in"), and `auth.LogOut` throwing (local wipe still happens, with a "check Settings → Devices manually" hint).
+
+### Changed
+
+- **`TelegramService.logOut()` hardened** — server-revoke and client-destroy are now split: a successful `auth.LogOut` returns `true` even if `client.destroy()` throws (previously misreported "not confirmed"). The local wipe is verified post-unlink and throws if the session file survives (e.g. read-only Docker mount), instead of falsely reporting success. File removal now always runs even when server-revoke fails (network error, `AUTH_KEY_UNREGISTERED`).
+- **Master cancels active QR login on logout** — a `telegram-logout` request now aborts an in-progress QR login flow before acquiring `globalLock`, instead of queuing behind it for up to 5 minutes.
+
+### Testing
+
+- 322 unit tests (+10 vs v1.28.0) — `hasLocalSession()`, `logOut()` edge cases (connected / disconnected±file / network error / idempotency / FS-throws / destroy-throws-but-revoke-succeeds), and a Master integration test that logout aborts an active login over a real unix socket.
+
+### Notes & known limitations
+
+- In a 3-client FIFO scenario (A holds the lock via login, B queues a tool call, C requests logout), logout correctly aborts A, but B still runs before logout because FIFO order is preserved. A priority-aware queue is deferred.
+
+## 1.28.0 — 2026-04-22 {#v1-28-0}
+
+### Added
+
+- **QR login through the IPC daemon** — `mcp-telegram login` now flows through the Master daemon over IPC instead of running as a separate process. The new session reaches the Master's memory immediately, with no editor restart. This fixes the "relogin via `mcp-telegram login`" flavor of `AUTH_KEY_DUPLICATED`/`AUTH_KEY_UNREGISTERED`, where the standalone login wrote a fresh session to disk but the running Master kept the old, now-invalidated auth key in memory and then wiped the just-created session on the next tool call.
+  - `IpcClient.loginFlow(onQr)` — streams QR frames as they refresh (~every 10s).
+  - `handleLoginStart` on Master — runs `startQrLogin` on the shared `TelegramService`.
+  - `GlobalLock` (FIFO mutex) — serializes tool calls with the login flow so other clients queue instead of hitting a stale client mid-relogin.
+  - `AbortController` — `socket.on("close")` aborts the QR loop if the CLI is interrupted (Ctrl+C / terminal closed); `globalLock` releases immediately instead of blocking tool calls for up to 5 minutes.
+  - Session swap now saves to disk first, then adopts in memory and destroys the previous client — prevents orphan Telegram connections accumulating per relogin.
+  - Standalone fallback kept — if no Master is running, `mcp-telegram login` works exactly as before.
+
+### Changed
+
+- **BREAKING (internal IPC only): IPC protocol is now a discriminated union** with a required `type` tag (`tool` / `tool_response` / `login_start` / `login_qr` / `login_done`). A new 1.28.0 client and an older 1.27.x Master cannot talk — restart your editor / Claude Code after upgrading so the Master daemon is replaced. No public API or invocation change. (Parent-crash detection already kills stale Masters in most cases, so this is transparent for VS Code / Claude Desktop users.)
+
+### Fixed
+
+- Socket errors on Master now log to stderr instead of being silently dropped.
+- `client.destroy()` in abort branches wrapped in try/catch — guarantees the "QR login aborted" message even if Telegram destroy throws.
+- QR render errors (`QRCode.toString` failure) logged to stderr instead of silently dropped.
+
+### Testing
+
+- 312 unit tests (was 288) — new suites for `GlobalLock` (FIFO ordering, double-release safety), Master login (QR URL forwarding, abort on socket close), child-process integration via tsx, `IpcClient.loginFlow`, and IPC discriminated-union / legacy-protocol rejection.
+
+## 1.27.1 — 2026-04-22 {#v1-27-1}
+
+### Changed
+
+- Patch release — no new tools, no API changes; pure code-quality and test-coverage work. Refactored `telegram-client.ts` re-exports (eliminates 2 Biome `noUnusedImports` false-positives), replaced unsafe `(e as Error).message` casts with `e instanceof Error` guards in the stats methods, and added `McpRegisteredTool` / `McpServerInternal` types to `ipc-protocol.ts` as a single source of truth (previously duplicated across master.ts and client.ts).
+
+### Testing
+
+- 286 unit tests (+25 vs v1.27.0) — new branch coverage for `wireIpcProxies` (incl. a safety test that the original `TelegramService` handler is never called after wiring), the rate limiter (`throwOnFloodWait`, retry exhaustion, 5xx, GramJS `errorMessage`), and the IPC protocol parser (malformed JSON, blank lines, partial-line buffering, multiple messages per chunk). `rate-limiter.ts` reached 100% statements.
+
+## 1.27.0 — 2026-04-21 {#v1-27-0}
+
+### Added
+
+- **Master/Client IPC daemon — fixes `AUTH_KEY_DUPLICATED` across concurrent Claude sessions.** Opening multiple Claude sessions used to spawn separate `mcp-telegram` processes that each connected to Telegram with the same session, which Telegram rejected as a duplicate. Now the first process to start becomes the **Master** (holds the single GramJS connection, listens on a Unix socket at `~/.mcp-telegram/daemon.sock`) and every subsequent process becomes a thin **Client** that proxies tool calls to the Master over the socket — one connection, one auth key, no duplicates. Zero config change; same invocation.
+  - Security: socket file is `chmod 0o600` (owner-only); the session string never leaves the Master process.
+
+### Fixed
+
+- Atomic lock via `O_EXCL` prevents a race when multiple sessions start simultaneously; stale socket from a previous crash is removed before `listen` (no `EADDRINUSE`).
+- One-shot connect timeout (not idle) so live connections survive inactivity; 30s IPC call timeout so a stuck Master surfaces a clean error instead of hanging.
+- Sequential `drainQueue()` loop for correct concurrent-request handling; `.catch()` on auto-connect to avoid `unhandledRejection`; idempotent cleanup (`cleanedUp` flag) so SIGINT/SIGTERM don't double-release.
 
 ## 1.26.0 — 2026-04-20 {#v1-26-0}
 
@@ -353,7 +423,7 @@ All notable changes to MCP Telegram. For the full diff between versions, see [Gi
 
 ### Changed
 
-- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+- `biome.json` migrated to schema 2.4.12
 
 ## 1.24.0 — 2026-04-06 {#v1-24-0}
 
@@ -450,6 +520,8 @@ All notable changes to MCP Telegram. For the full diff between versions, see [Gi
 
 ### Changed
 
+- Updated Biome to 2.4.9 with new config schema
+- Sorted imports for Biome compliance
 - Added proxy documentation to README
 
 ## 1.13.0 — 2026-03-26 {#v1-13-0}
@@ -518,6 +590,7 @@ All notable changes to MCP Telegram. For the full diff between versions, see [Gi
 - Updated session path and security documentation
 - Upgraded GitHub Actions to v6
 - Replaced Node 20 with Node 24 in CI
+- Updated Biome to 2.4.7 and @types/node to 25.5.0
 
 ## 1.8.1 — 2026-03-19 {#v1-8-1}
 
@@ -555,6 +628,7 @@ All notable changes to MCP Telegram. For the full diff between versions, see [Gi
 ### Changed
 
 - Removed hardcoded tool counts from README and package.json
+- Updated Biome to 2.4.7 and @types/node to 25.5.0
 
 ## 1.5.0 — 2026-03-16 {#v1-5-0}
 

--- a/docs/ru/changelog.md
+++ b/docs/ru/changelog.md
@@ -53,6 +53,7 @@
 
 ### Changed
 
+  - `biome.json` schema bumped to 2.4.15 via `biome migrate --write`
   - `hono` 4.12.9 → 4.12.18 (CSS injection in JSX SSR, JWT NumericDate, Cache `Vary`, etc.)
   - `fast-uri` 3.1.0 → 3.1.2 (host confusion + path traversal)
   - `ip-address` 10.1.0 → 10.2.0 (Address6 HTML XSS)
@@ -262,6 +263,7 @@
 ### Security
 
 - `quoteText` without `replyTo` now raises a clear error instead of silently dropping the quote.
+- GramJS private `_parseMessageText` usage in the quoteText/effect raw path is feature-detected; future GramJS bumps surface a clear "version incompatible" error instead of crashing.
 - `effect` ID regex tightened to `^\d{1,19}$` (Int64-safe range).
 
 ### Testing
@@ -277,6 +279,74 @@
 - **`telegram-send-voice.duration` removed vs. initial design** — GramJS auto-detects duration from the audio file; letting the AI override it caused the Telegram UI to display wrong playback times.
 - **Album mixed photo+video** — GramJS accepts mixed arrays via extension-based detection, but this is not covered by tests; recommend uniform media type per album until a live-test checkpoint confirms.
 - **Album flood control** — a 10-item album fans out 10 `messages.UploadMedia` calls inside one rate-limit slot; under heavy contention the later items may still hit `FLOOD_WAIT`. Rate limiter retries apply.
+
+## 1.28.1 — 2026-04-22 {#v1-28-1}
+
+### Added
+
+- **`telegram-logout`** — new tool (Auth category, annotated `DESTRUCTIVE`). Fully logs out: calls `auth.LogOut` on Telegram servers (session disappears from Settings → Devices), destroys the GramJS client, deletes the local session file, and clears in-memory state. Takes no parameters. Handles every state cleanly — connected (server revoke + local wipe), disconnected with a session file (local wipe only, with a notice), no session (`fail` "Not logged in"), and `auth.LogOut` throwing (local wipe still happens, with a "check Settings → Devices manually" hint).
+
+### Changed
+
+- **`TelegramService.logOut()` hardened** — server-revoke and client-destroy are now split: a successful `auth.LogOut` returns `true` even if `client.destroy()` throws (previously misreported "not confirmed"). The local wipe is verified post-unlink and throws if the session file survives (e.g. read-only Docker mount), instead of falsely reporting success. File removal now always runs even when server-revoke fails (network error, `AUTH_KEY_UNREGISTERED`).
+- **Master cancels active QR login on logout** — a `telegram-logout` request now aborts an in-progress QR login flow before acquiring `globalLock`, instead of queuing behind it for up to 5 minutes.
+
+### Testing
+
+- 322 unit tests (+10 vs v1.28.0) — `hasLocalSession()`, `logOut()` edge cases (connected / disconnected±file / network error / idempotency / FS-throws / destroy-throws-but-revoke-succeeds), and a Master integration test that logout aborts an active login over a real unix socket.
+
+### Notes & known limitations
+
+- In a 3-client FIFO scenario (A holds the lock via login, B queues a tool call, C requests logout), logout correctly aborts A, but B still runs before logout because FIFO order is preserved. A priority-aware queue is deferred.
+
+## 1.28.0 — 2026-04-22 {#v1-28-0}
+
+### Added
+
+- **QR login through the IPC daemon** — `mcp-telegram login` now flows through the Master daemon over IPC instead of running as a separate process. The new session reaches the Master's memory immediately, with no editor restart. This fixes the "relogin via `mcp-telegram login`" flavor of `AUTH_KEY_DUPLICATED`/`AUTH_KEY_UNREGISTERED`, where the standalone login wrote a fresh session to disk but the running Master kept the old, now-invalidated auth key in memory and then wiped the just-created session on the next tool call.
+  - `IpcClient.loginFlow(onQr)` — streams QR frames as they refresh (~every 10s).
+  - `handleLoginStart` on Master — runs `startQrLogin` on the shared `TelegramService`.
+  - `GlobalLock` (FIFO mutex) — serializes tool calls with the login flow so other clients queue instead of hitting a stale client mid-relogin.
+  - `AbortController` — `socket.on("close")` aborts the QR loop if the CLI is interrupted (Ctrl+C / terminal closed); `globalLock` releases immediately instead of blocking tool calls for up to 5 minutes.
+  - Session swap now saves to disk first, then adopts in memory and destroys the previous client — prevents orphan Telegram connections accumulating per relogin.
+  - Standalone fallback kept — if no Master is running, `mcp-telegram login` works exactly as before.
+
+### Changed
+
+- **BREAKING (internal IPC only): IPC protocol is now a discriminated union** with a required `type` tag (`tool` / `tool_response` / `login_start` / `login_qr` / `login_done`). A new 1.28.0 client and an older 1.27.x Master cannot talk — restart your editor / Claude Code after upgrading so the Master daemon is replaced. No public API or invocation change. (Parent-crash detection already kills stale Masters in most cases, so this is transparent for VS Code / Claude Desktop users.)
+
+### Fixed
+
+- Socket errors on Master now log to stderr instead of being silently dropped.
+- `client.destroy()` in abort branches wrapped in try/catch — guarantees the "QR login aborted" message even if Telegram destroy throws.
+- QR render errors (`QRCode.toString` failure) logged to stderr instead of silently dropped.
+
+### Testing
+
+- 312 unit tests (was 288) — new suites for `GlobalLock` (FIFO ordering, double-release safety), Master login (QR URL forwarding, abort on socket close), child-process integration via tsx, `IpcClient.loginFlow`, and IPC discriminated-union / legacy-protocol rejection.
+
+## 1.27.1 — 2026-04-22 {#v1-27-1}
+
+### Changed
+
+- Patch release — no new tools, no API changes; pure code-quality and test-coverage work. Refactored `telegram-client.ts` re-exports (eliminates 2 Biome `noUnusedImports` false-positives), replaced unsafe `(e as Error).message` casts with `e instanceof Error` guards in the stats methods, and added `McpRegisteredTool` / `McpServerInternal` types to `ipc-protocol.ts` as a single source of truth (previously duplicated across master.ts and client.ts).
+
+### Testing
+
+- 286 unit tests (+25 vs v1.27.0) — new branch coverage for `wireIpcProxies` (incl. a safety test that the original `TelegramService` handler is never called after wiring), the rate limiter (`throwOnFloodWait`, retry exhaustion, 5xx, GramJS `errorMessage`), and the IPC protocol parser (malformed JSON, blank lines, partial-line buffering, multiple messages per chunk). `rate-limiter.ts` reached 100% statements.
+
+## 1.27.0 — 2026-04-21 {#v1-27-0}
+
+### Added
+
+- **Master/Client IPC daemon — fixes `AUTH_KEY_DUPLICATED` across concurrent Claude sessions.** Opening multiple Claude sessions used to spawn separate `mcp-telegram` processes that each connected to Telegram with the same session, which Telegram rejected as a duplicate. Now the first process to start becomes the **Master** (holds the single GramJS connection, listens on a Unix socket at `~/.mcp-telegram/daemon.sock`) and every subsequent process becomes a thin **Client** that proxies tool calls to the Master over the socket — one connection, one auth key, no duplicates. Zero config change; same invocation.
+  - Security: socket file is `chmod 0o600` (owner-only); the session string never leaves the Master process.
+
+### Fixed
+
+- Atomic lock via `O_EXCL` prevents a race when multiple sessions start simultaneously; stale socket from a previous crash is removed before `listen` (no `EADDRINUSE`).
+- One-shot connect timeout (not idle) so live connections survive inactivity; 30s IPC call timeout so a stuck Master surfaces a clean error instead of hanging.
+- Sequential `drainQueue()` loop for correct concurrent-request handling; `.catch()` on auto-connect to avoid `unhandledRejection`; idempotent cleanup (`cleanedUp` flag) so SIGINT/SIGTERM don't double-release.
 
 ## 1.26.0 — 2026-04-20 {#v1-26-0}
 
@@ -353,7 +423,7 @@
 
 ### Changed
 
-- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+- `biome.json` migrated to schema 2.4.12
 
 ## 1.24.0 — 2026-04-06 {#v1-24-0}
 
@@ -450,6 +520,8 @@
 
 ### Changed
 
+- Updated Biome to 2.4.9 with new config schema
+- Sorted imports for Biome compliance
 - Added proxy documentation to README
 
 ## 1.13.0 — 2026-03-26 {#v1-13-0}
@@ -518,6 +590,7 @@
 - Updated session path and security documentation
 - Upgraded GitHub Actions to v6
 - Replaced Node 20 with Node 24 in CI
+- Updated Biome to 2.4.7 and @types/node to 25.5.0
 
 ## 1.8.1 — 2026-03-19 {#v1-8-1}
 
@@ -555,6 +628,7 @@
 ### Changed
 
 - Removed hardcoded tool counts from README and package.json
+- Updated Biome to 2.4.7 and @types/node to 25.5.0
 
 ## 1.5.0 — 2026-03-16 {#v1-5-0}
 

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -53,6 +53,7 @@ MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](htt
 
 ### Changed
 
+  - `biome.json` schema bumped to 2.4.15 via `biome migrate --write`
   - `hono` 4.12.9 → 4.12.18 (CSS injection in JSX SSR, JWT NumericDate, Cache `Vary`, etc.)
   - `fast-uri` 3.1.0 → 3.1.2 (host confusion + path traversal)
   - `ip-address` 10.1.0 → 10.2.0 (Address6 HTML XSS)
@@ -262,6 +263,7 @@ MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](htt
 ### Security
 
 - `quoteText` without `replyTo` now raises a clear error instead of silently dropping the quote.
+- GramJS private `_parseMessageText` usage in the quoteText/effect raw path is feature-detected; future GramJS bumps surface a clear "version incompatible" error instead of crashing.
 - `effect` ID regex tightened to `^\d{1,19}$` (Int64-safe range).
 
 ### Testing
@@ -277,6 +279,74 @@ MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](htt
 - **`telegram-send-voice.duration` removed vs. initial design** — GramJS auto-detects duration from the audio file; letting the AI override it caused the Telegram UI to display wrong playback times.
 - **Album mixed photo+video** — GramJS accepts mixed arrays via extension-based detection, but this is not covered by tests; recommend uniform media type per album until a live-test checkpoint confirms.
 - **Album flood control** — a 10-item album fans out 10 `messages.UploadMedia` calls inside one rate-limit slot; under heavy contention the later items may still hit `FLOOD_WAIT`. Rate limiter retries apply.
+
+## 1.28.1 — 2026-04-22 {#v1-28-1}
+
+### Added
+
+- **`telegram-logout`** — new tool (Auth category, annotated `DESTRUCTIVE`). Fully logs out: calls `auth.LogOut` on Telegram servers (session disappears from Settings → Devices), destroys the GramJS client, deletes the local session file, and clears in-memory state. Takes no parameters. Handles every state cleanly — connected (server revoke + local wipe), disconnected with a session file (local wipe only, with a notice), no session (`fail` "Not logged in"), and `auth.LogOut` throwing (local wipe still happens, with a "check Settings → Devices manually" hint).
+
+### Changed
+
+- **`TelegramService.logOut()` hardened** — server-revoke and client-destroy are now split: a successful `auth.LogOut` returns `true` even if `client.destroy()` throws (previously misreported "not confirmed"). The local wipe is verified post-unlink and throws if the session file survives (e.g. read-only Docker mount), instead of falsely reporting success. File removal now always runs even when server-revoke fails (network error, `AUTH_KEY_UNREGISTERED`).
+- **Master cancels active QR login on logout** — a `telegram-logout` request now aborts an in-progress QR login flow before acquiring `globalLock`, instead of queuing behind it for up to 5 minutes.
+
+### Testing
+
+- 322 unit tests (+10 vs v1.28.0) — `hasLocalSession()`, `logOut()` edge cases (connected / disconnected±file / network error / idempotency / FS-throws / destroy-throws-but-revoke-succeeds), and a Master integration test that logout aborts an active login over a real unix socket.
+
+### Notes & known limitations
+
+- In a 3-client FIFO scenario (A holds the lock via login, B queues a tool call, C requests logout), logout correctly aborts A, but B still runs before logout because FIFO order is preserved. A priority-aware queue is deferred.
+
+## 1.28.0 — 2026-04-22 {#v1-28-0}
+
+### Added
+
+- **QR login through the IPC daemon** — `mcp-telegram login` now flows through the Master daemon over IPC instead of running as a separate process. The new session reaches the Master's memory immediately, with no editor restart. This fixes the "relogin via `mcp-telegram login`" flavor of `AUTH_KEY_DUPLICATED`/`AUTH_KEY_UNREGISTERED`, where the standalone login wrote a fresh session to disk but the running Master kept the old, now-invalidated auth key in memory and then wiped the just-created session on the next tool call.
+  - `IpcClient.loginFlow(onQr)` — streams QR frames as they refresh (~every 10s).
+  - `handleLoginStart` on Master — runs `startQrLogin` on the shared `TelegramService`.
+  - `GlobalLock` (FIFO mutex) — serializes tool calls with the login flow so other clients queue instead of hitting a stale client mid-relogin.
+  - `AbortController` — `socket.on("close")` aborts the QR loop if the CLI is interrupted (Ctrl+C / terminal closed); `globalLock` releases immediately instead of blocking tool calls for up to 5 minutes.
+  - Session swap now saves to disk first, then adopts in memory and destroys the previous client — prevents orphan Telegram connections accumulating per relogin.
+  - Standalone fallback kept — if no Master is running, `mcp-telegram login` works exactly as before.
+
+### Changed
+
+- **BREAKING (internal IPC only): IPC protocol is now a discriminated union** with a required `type` tag (`tool` / `tool_response` / `login_start` / `login_qr` / `login_done`). A new 1.28.0 client and an older 1.27.x Master cannot talk — restart your editor / Claude Code after upgrading so the Master daemon is replaced. No public API or invocation change. (Parent-crash detection already kills stale Masters in most cases, so this is transparent for VS Code / Claude Desktop users.)
+
+### Fixed
+
+- Socket errors on Master now log to stderr instead of being silently dropped.
+- `client.destroy()` in abort branches wrapped in try/catch — guarantees the "QR login aborted" message even if Telegram destroy throws.
+- QR render errors (`QRCode.toString` failure) logged to stderr instead of silently dropped.
+
+### Testing
+
+- 312 unit tests (was 288) — new suites for `GlobalLock` (FIFO ordering, double-release safety), Master login (QR URL forwarding, abort on socket close), child-process integration via tsx, `IpcClient.loginFlow`, and IPC discriminated-union / legacy-protocol rejection.
+
+## 1.27.1 — 2026-04-22 {#v1-27-1}
+
+### Changed
+
+- Patch release — no new tools, no API changes; pure code-quality and test-coverage work. Refactored `telegram-client.ts` re-exports (eliminates 2 Biome `noUnusedImports` false-positives), replaced unsafe `(e as Error).message` casts with `e instanceof Error` guards in the stats methods, and added `McpRegisteredTool` / `McpServerInternal` types to `ipc-protocol.ts` as a single source of truth (previously duplicated across master.ts and client.ts).
+
+### Testing
+
+- 286 unit tests (+25 vs v1.27.0) — new branch coverage for `wireIpcProxies` (incl. a safety test that the original `TelegramService` handler is never called after wiring), the rate limiter (`throwOnFloodWait`, retry exhaustion, 5xx, GramJS `errorMessage`), and the IPC protocol parser (malformed JSON, blank lines, partial-line buffering, multiple messages per chunk). `rate-limiter.ts` reached 100% statements.
+
+## 1.27.0 — 2026-04-21 {#v1-27-0}
+
+### Added
+
+- **Master/Client IPC daemon — fixes `AUTH_KEY_DUPLICATED` across concurrent Claude sessions.** Opening multiple Claude sessions used to spawn separate `mcp-telegram` processes that each connected to Telegram with the same session, which Telegram rejected as a duplicate. Now the first process to start becomes the **Master** (holds the single GramJS connection, listens on a Unix socket at `~/.mcp-telegram/daemon.sock`) and every subsequent process becomes a thin **Client** that proxies tool calls to the Master over the socket — one connection, one auth key, no duplicates. Zero config change; same invocation.
+  - Security: socket file is `chmod 0o600` (owner-only); the session string never leaves the Master process.
+
+### Fixed
+
+- Atomic lock via `O_EXCL` prevents a race when multiple sessions start simultaneously; stale socket from a previous crash is removed before `listen` (no `EADDRINUSE`).
+- One-shot connect timeout (not idle) so live connections survive inactivity; 30s IPC call timeout so a stuck Master surfaces a clean error instead of hanging.
+- Sequential `drainQueue()` loop for correct concurrent-request handling; `.catch()` on auto-connect to avoid `unhandledRejection`; idempotent cleanup (`cleanedUp` flag) so SIGINT/SIGTERM don't double-release.
 
 ## 1.26.0 — 2026-04-20 {#v1-26-0}
 
@@ -353,7 +423,7 @@ MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](htt
 
 ### Changed
 
-- Internal maintenance: dependency, build, or documentation updates only (no user-facing changes).
+- `biome.json` migrated to schema 2.4.12
 
 ## 1.24.0 — 2026-04-06 {#v1-24-0}
 
@@ -450,6 +520,8 @@ MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](htt
 
 ### Changed
 
+- Updated Biome to 2.4.9 with new config schema
+- Sorted imports for Biome compliance
 - Added proxy documentation to README
 
 ## 1.13.0 — 2026-03-26 {#v1-13-0}
@@ -518,6 +590,7 @@ MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](htt
 - Updated session path and security documentation
 - Upgraded GitHub Actions to v6
 - Replaced Node 20 with Node 24 in CI
+- Updated Biome to 2.4.7 and @types/node to 25.5.0
 
 ## 1.8.1 — 2026-03-19 {#v1-8-1}
 
@@ -555,6 +628,7 @@ MCP Telegram 的所有重要更改。完整版本对比见 [GitHub Releases](htt
 ### Changed
 
 - Removed hardcoded tool counts from README and package.json
+- Updated Biome to 2.4.7 and @types/node to 25.5.0
 
 ## 1.5.0 — 2026-03-16 {#v1-5-0}
 

--- a/scripts/gen-changelog-docs.ts
+++ b/scripts/gen-changelog-docs.ts
@@ -46,10 +46,16 @@ function cleanLine(line: string): string {
 /** Conventional-commit scopes that carry no user-facing signal. */
 const NOISE_SCOPE = /^\s*-\s+\*\*(deps|build|ci|chore|docs|test|style|refactor)(\([^)]*\))?:\*\*/i;
 
-/** A single bullet is noise if it's a noise-scoped commit or a plain deps bump. */
+/** A single bullet is noise if it's a noise-scoped commit or a plain deps bump.
+ * Deps wording (e.g. "Dependency update", "bump … → …") is reliable noise; a
+ * bare tool name like "biome"/"tsx" is NOT — it appears in real refactor notes
+ * ("eliminates 2 Biome false-positives"), so we only treat it as a bump when a
+ * version arrow accompanies it. */
 function isNoiseBullet(line: string): boolean {
   if (NOISE_SCOPE.test(line)) return true;
-  return /^\s*-\s+.*\b(dependenc|devdep|bump|lockfile|biome|tsx|npm audit)/i.test(line);
+  if (/^\s*-\s+.*\b(dependenc|devdep|lockfile|npm audit)/i.test(line)) return true;
+  // "bump X → Y" / "X 1.2.3 → 1.2.4" style version bumps
+  return /^\s*-\s+.*\bbump\b/i.test(line) && /[→]|->|\bv?\d+\.\d+\.\d+\b/.test(line);
 }
 
 /** Parse CHANGELOG.md into version entries (newest first, as written). */


### PR DESCRIPTION
Follow-up to #54, closing the two tails it surfaced.

## 1. Backfill missing CHANGELOG versions

`CHANGELOG.md` was missing **four releases** that shipped (git tags + GitHub Releases exist) but never made it into the file:

| Version | What |
|---|---|
| **1.27.0** | Master/Client IPC daemon — the permanent `AUTH_KEY_DUPLICATED` fix across concurrent Claude sessions |
| **1.27.1** | code-quality patch (refactor, +25 tests) |
| **1.28.0** | QR login via the IPC daemon (fixes relogin `AUTH_KEY_UNREGISTERED`), discriminated-union IPC protocol |
| **1.28.1** | `telegram-logout` tool + `logOut()` hardening |

Restored from the published Release notes, condensed into the file's Keep-a-Changelog style. The generated docs pages now cover **53 versions** (was 49) — the gap that #54's self-review flagged is closed.

## 2. Generator fix (noise heuristic false-positive)

`isNoiseBullet` treated a bare `biome`/`tsx` mention as a deps bump — which swallowed 1.27.1's real `### Changed` (it mentions a Biome false-positive *it fixed*). A tool name now only reads as noise when a version arrow (`→` / a version number) accompanies it. Verified deps-only releases (1.36.4 / 1.36.5 / 1.38.1) still collapse to the one-line "Internal maintenance" as before.

## 3. Bump Pages actions off Node 20

`docs.yml` was the last workflow on Node-20 actions (deploy logged a deprecation warning, forced onto Node 24):
- `checkout` v4 → v6, `setup-node` v4 → v6 (node 20 → 22, matching ci.yml)
- `upload-pages-artifact` v3 → v5, `deploy-pages` v4 → v5

No remaining Node-20 actions in any workflow.

## Verification

- `gen:changelog:check` in sync, `docs:build` green, generator lints clean.
- 53 versions in all three locale pages; 1.27.1 now renders its `### Changed`, deps releases still collapse.

## Not in this PR (noted, needs its own look)

`release-please-action@v4` → latest is **v5.0.0** (major bump, release pipeline — wants migration-note review before bumping). Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)