### PR TITLE
feat: complete QR login for accounts with 2FA

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ A QR code will appear in the terminal. Open Telegram on your phone, go to **Sett
 
 > **Custom session path:** set `TELEGRAM_SESSION_PATH=/path/to/session` to store the session file elsewhere.
 
+> **Two-step verification (2FA):** if your account has a cloud password enabled, scanning the QR code is not enough — Telegram also requires the password. Provide it via `TELEGRAM_2FA_PASSWORD` so the login can complete:
+>
+> ```bash
+> TELEGRAM_API_ID=YOUR_ID TELEGRAM_API_HASH=YOUR_HASH TELEGRAM_2FA_PASSWORD=YOUR_PASSWORD npx @overpod/mcp-telegram login
+> ```
+>
+> The password is only used locally to answer Telegram's SRP challenge and is never persisted.
+
 ### 3. Add to Claude
 
 ```bash

--- a/src/telegram-client.ts
+++ b/src/telegram-client.ts
@@ -8,6 +8,7 @@ import QRCode from "qrcode";
 import { TelegramClient } from "telegram";
 import { CustomFile } from "telegram/client/uploads.js";
 import type { ProxyInterface } from "telegram/network/connection/TCPMTProxy.js";
+import { computeCheck } from "telegram/Password.js";
 import { StringSession } from "telegram/sessions/index.js";
 import { Api } from "telegram/tl/index.js";
 import { RateLimiter } from "./rate-limiter.js";
@@ -194,6 +195,16 @@ const NOT_CONNECTED_ERROR = "Not connected. Run telegram-status to check or tele
 
 function resolveSessionPath(sessionPath?: string): string {
   return sessionPath ?? process.env.TELEGRAM_SESSION_PATH ?? DEFAULT_SESSION_FILE;
+}
+
+// Cloud password (2FA) for accounts that have two-step verification enabled.
+// QR login alone cannot complete such logins — Telegram answers the imported
+// login token with SESSION_PASSWORD_NEEDED, after which an SRP password check
+// is required. Supplied via env so it works across all login entry points
+// (standalone CLI, daemon IPC, and the telegram-login MCP tool), none of which
+// can reliably prompt interactively mid-flow.
+function resolveTwoFactorPassword(): string | undefined {
+  return process.env.TELEGRAM_2FA_PASSWORD || undefined;
 }
 
 function resolveProxy(): ProxyInterface | undefined {
@@ -525,8 +536,32 @@ export class TelegramService {
         } catch (err: unknown) {
           const error = err as { errorMessage?: string; message?: string };
           if (error.errorMessage === "SESSION_PASSWORD_NEEDED") {
-            await client.disconnect();
-            return { success: false, message: "2FA enabled — QR login not supported with 2FA" };
+            // The QR was scanned, but the account has two-step verification.
+            // Complete the login with an SRP password check if we have the
+            // cloud password; otherwise tell the user how to provide it.
+            const password = resolveTwoFactorPassword();
+            if (!password) {
+              await client.disconnect();
+              return {
+                success: false,
+                message:
+                  "2FA is enabled on this account. Set TELEGRAM_2FA_PASSWORD to your cloud password and run login again.",
+              };
+            }
+            try {
+              const passwordInfo = await client.invoke(new Api.account.GetPassword());
+              const check = await computeCheck(passwordInfo, password);
+              await client.invoke(new Api.auth.CheckPassword({ password: check }));
+              resolved = true;
+              break;
+            } catch (pwErr: unknown) {
+              await client.disconnect();
+              const reason = pwErr instanceof Error ? pwErr.message : String(pwErr);
+              return {
+                success: false,
+                message: `2FA password check failed: ${reason}. Verify TELEGRAM_2FA_PASSWORD is correct.`,
+              };
+            }
           }
         }
 

--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -67,6 +67,8 @@ export function registerAuthTools(server: McpServer, telegram: TelegramService) 
         `If the QR image is not visible, it's also saved to: ${qrFilePath}`,
         "",
         "After scanning, run **telegram-status** to verify the connection.",
+        "",
+        "If the account has two-step verification (2FA), set the `TELEGRAM_2FA_PASSWORD` environment variable to the cloud password and log in again — scanning alone cannot complete a 2FA login.",
       ].join("\n");
 
       return {


### PR DESCRIPTION
## Problem

QR login aborts for any account with two-step verification enabled:

```
2FA enabled — QR login not supported with 2FA
```

After the QR is scanned, Telegram imports the login token and then replies
with `SESSION_PASSWORD_NEEDED` for 2FA-protected accounts. The current code
catches that and bails, so these users have no built-in way to log in.

## Change

Handle `SESSION_PASSWORD_NEEDED` inside `startQrLogin` by completing the SRP
password check:

- `account.GetPassword` → `computeCheck(passwordInfo, password)` → `auth.CheckPassword`
- on success, resume the existing session-save path (no other flow changes)

The cloud password is read from a new **`TELEGRAM_2FA_PASSWORD`** env var. Env
was chosen deliberately so the fix works across **all three** login entry
points — standalone CLI, daemon IPC, and the `telegram-login` MCP tool — none
of which can reliably prompt for a password mid-flow. It mirrors how the
project already passes secrets like `TELEGRAM_PROXY_PASSWORD`.

When 2FA is required but the variable is unset, the error message now tells the
user exactly how to supply it, and a wrong password surfaces a clear failure.

## Usage

```bash
TELEGRAM_API_ID=... TELEGRAM_API_HASH=... TELEGRAM_2FA_PASSWORD=... npx @overpod/mcp-telegram login
```
