### PR TITLE
feat: complete QR login for accounts with 2FA

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ A QR code will appear in the terminal. Open Telegram on your phone, go to **Sett
 
 > **Custom session path:** set `TELEGRAM_SESSION_PATH=/path/to/session` to store the session file elsewhere.
 
+> **Two-step verification (2FA):** if your account has a cloud password enabled, scanning the QR code is not enough — Telegram also requires the password. Provide it via `TELEGRAM_2FA_PASSWORD` so the login can complete:
+>
+> ```bash
+> TELEGRAM_API_ID=YOUR_ID TELEGRAM_API_HASH=YOUR_HASH TELEGRAM_2FA_PASSWORD=YOUR_PASSWORD npx @overpod/mcp-telegram login
+> ```
+>
+> The password is only used locally to answer Telegram's SRP challenge and is never persisted.
+
 ### 3. Add to Claude
 
 ```bash

--- a/src/__tests__/two-factor-login.test.ts
+++ b/src/__tests__/two-factor-login.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Api } from "telegram/tl/index.js";
+import { completeTwoFactorLogin } from "../telegram-client.js";
+
+/**
+ * Tests for the SRP cloud-password (2FA) step of QR login. The branch runs when
+ * Telegram answers a scanned QR with SESSION_PASSWORD_NEEDED. We stub the client
+ * `invoke` and inject a fake `compute` so the GetPassword → computeCheck →
+ * CheckPassword orchestration is exercised without GramJS's real crypto or a
+ * live TelegramClient.
+ */
+
+/** Opaque stand-ins — the helper only forwards these between calls, never
+ *  inspects them (the real crypto lives in the injected `compute`). */
+const PASSWORD_INFO = { _: "account.password" } as unknown as Api.account.Password;
+const fakeSrp = { _: "inputCheckPasswordSRP" } as unknown as Api.TypeInputCheckPasswordSRP;
+
+const okCompute = async () => fakeSrp;
+
+describe("completeTwoFactorLogin", () => {
+  it("returns a guiding message when no password is supplied", async () => {
+    let invoked = false;
+    const client = {
+      invoke: async () => {
+        invoked = true;
+        return undefined;
+      },
+    };
+
+    const outcome = await completeTwoFactorLogin(client, undefined, okCompute);
+
+    assert.strictEqual(outcome.ok, false);
+    assert.ok(!invoked, "must not contact Telegram when there is no password to check");
+    assert.match(outcome.ok === false ? outcome.message : "", /TELEGRAM_2FA_PASSWORD/);
+  });
+
+  it("treats an empty-string password as missing", async () => {
+    const outcome = await completeTwoFactorLogin({ invoke: async () => undefined }, "", okCompute);
+    assert.strictEqual(outcome.ok, false);
+    assert.match(outcome.ok === false ? outcome.message : "", /2FA is enabled/);
+  });
+
+  it("surfaces a clear failure when the SRP check is rejected", async () => {
+    const client = {
+      invoke: async (request: unknown) => {
+        if (request instanceof Api.account.GetPassword) return PASSWORD_INFO;
+        // Telegram rejects a wrong cloud password at CheckPassword
+        throw Object.assign(new Error("PASSWORD_HASH_INVALID"), {
+          errorMessage: "PASSWORD_HASH_INVALID",
+        });
+      },
+    };
+
+    const outcome = await completeTwoFactorLogin(client, "wrong-password", okCompute);
+
+    assert.strictEqual(outcome.ok, false);
+    const msg = outcome.ok === false ? outcome.message : "";
+    assert.match(msg, /2FA password check failed/);
+    assert.match(msg, /PASSWORD_HASH_INVALID/);
+    assert.match(msg, /Verify TELEGRAM_2FA_PASSWORD/);
+    assert.ok(!msg.includes("wrong-password"), "must never echo the password back");
+  });
+
+  it("maps a thrown computeCheck (malformed SRP params) to a clear failure", async () => {
+    const client = {
+      invoke: async (request: unknown) => {
+        if (request instanceof Api.account.GetPassword) return PASSWORD_INFO;
+        throw new Error("CheckPassword should not be reached");
+      },
+    };
+    const throwingCompute = async () => {
+      throw new Error("Invalid password params");
+    };
+
+    const outcome = await completeTwoFactorLogin(client, "pw", throwingCompute);
+
+    assert.strictEqual(outcome.ok, false);
+    assert.match(outcome.ok === false ? outcome.message : "", /2FA password check failed: Invalid password params/);
+  });
+
+  it("succeeds when GetPassword and CheckPassword both resolve", async () => {
+    const calls: string[] = [];
+    let srpHandedToCheck: unknown;
+    const client = {
+      invoke: async (request: unknown) => {
+        if (request instanceof Api.account.GetPassword) {
+          calls.push("GetPassword");
+          return PASSWORD_INFO;
+        }
+        if (request instanceof Api.auth.CheckPassword) {
+          calls.push("CheckPassword");
+          srpHandedToCheck = request.password;
+          // Helper ignores the return value; a sentinel is enough.
+          return { _: "auth.authorization" };
+        }
+        throw new Error(`unexpected invoke: ${String(request)}`);
+      },
+    };
+
+    const outcome = await completeTwoFactorLogin(client, "correct-password", okCompute);
+
+    assert.strictEqual(outcome.ok, true);
+    assert.deepStrictEqual(calls, ["GetPassword", "CheckPassword"]);
+    assert.strictEqual(srpHandedToCheck, fakeSrp, "computed SRP must flow into CheckPassword");
+  });
+});

--- a/src/telegram-client.ts
+++ b/src/telegram-client.ts
@@ -8,6 +8,7 @@ import QRCode from "qrcode";
 import { TelegramClient } from "telegram";
 import { CustomFile } from "telegram/client/uploads.js";
 import type { ProxyInterface } from "telegram/network/connection/TCPMTProxy.js";
+import { computeCheck } from "telegram/Password.js";
 import { StringSession } from "telegram/sessions/index.js";
 import { Api } from "telegram/tl/index.js";
 import { RateLimiter } from "./rate-limiter.js";
@@ -194,6 +195,16 @@ const NOT_CONNECTED_ERROR = "Not connected. Run telegram-status to check or tele
 
 function resolveSessionPath(sessionPath?: string): string {
   return sessionPath ?? process.env.TELEGRAM_SESSION_PATH ?? DEFAULT_SESSION_FILE;
+}
+
+// Cloud password (2FA) for accounts that have two-step verification enabled.
+// QR login alone cannot complete such logins — Telegram answers the imported
+// login token with SESSION_PASSWORD_NEEDED, after which an SRP password check
+// is required. Supplied via env so it works across all login entry points
+// (standalone CLI, daemon IPC, and the telegram-login MCP tool), none of which
+// can reliably prompt interactively mid-flow.
+function resolveTwoFactorPassword(): string | undefined {
+  return process.env.TELEGRAM_2FA_PASSWORD || undefined;
 }
 
 function resolveProxy(): ProxyInterface | undefined {
@@ -525,8 +536,32 @@ export class TelegramService {
         } catch (err: unknown) {
           const error = err as { errorMessage?: string; message?: string };
           if (error.errorMessage === "SESSION_PASSWORD_NEEDED") {
-            await client.disconnect();
-            return { success: false, message: "2FA enabled — QR login not supported with 2FA" };
+            // The QR was scanned, but the account has two-step verification.
+            // Complete the login with an SRP password check if we have the
+            // cloud password; otherwise tell the user how to provide it.
+            const password = resolveTwoFactorPassword();
+            if (!password) {
+              await client.disconnect();
+              return {
+                success: false,
+                message:
+                  "2FA is enabled on this account. Set TELEGRAM_2FA_PASSWORD to your cloud password and run login again.",
+              };
+            }
+            try {
+              const passwordInfo = await client.invoke(new Api.account.GetPassword());
+              const check = await computeCheck(passwordInfo, password);
+              await client.invoke(new Api.auth.CheckPassword({ password: check }));
+              resolved = true;
+              break;
+            } catch (pwErr: unknown) {
+              await client.disconnect();
+              const reason = pwErr instanceof Error ? pwErr.message : String(pwErr);
+              return {
+                success: false,
+                message: `2FA password check failed: ${reason}. Verify TELEGRAM_2FA_PASSWORD is correct.`,
+              };
+            }
           }
         }
 

--- a/src/telegram-client.ts
+++ b/src/telegram-client.ts
@@ -207,6 +207,51 @@ function resolveTwoFactorPassword(): string | undefined {
   return process.env.TELEGRAM_2FA_PASSWORD || undefined;
 }
 
+/** Minimal client surface the 2FA SRP step needs — lets us unit-test the
+ *  branch logic with a stub instead of a live TelegramClient. */
+interface SrpClient {
+  invoke(request: unknown): Promise<unknown>;
+}
+
+/** The SRP digest function (GetPassword response + plaintext → InputCheckPasswordSRP).
+ *  Injectable so tests can exercise the orchestration without GramJS's real crypto. */
+type ComputeCheckFn = (request: Api.account.Password, password: string) => Promise<Api.TypeInputCheckPasswordSRP>;
+
+/**
+ * Complete a QR login that Telegram answered with SESSION_PASSWORD_NEEDED by
+ * running the SRP cloud-password check: GetPassword → computeCheck → CheckPassword.
+ *
+ * Returns a discriminated outcome rather than throwing so the caller owns
+ * connection teardown. The password is only used to answer the SRP challenge
+ * and is never logged or persisted.
+ *
+ * `compute` is injectable for tests; production always uses GramJS `computeCheck`.
+ */
+export async function completeTwoFactorLogin(
+  client: SrpClient,
+  password: string | undefined,
+  compute: ComputeCheckFn = computeCheck,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  if (!password) {
+    return {
+      ok: false,
+      message: "2FA is enabled on this account. Set TELEGRAM_2FA_PASSWORD to your cloud password and run login again.",
+    };
+  }
+  try {
+    const passwordInfo = (await client.invoke(new Api.account.GetPassword())) as Api.account.Password;
+    const check = await compute(passwordInfo, password);
+    await client.invoke(new Api.auth.CheckPassword({ password: check }));
+    return { ok: true };
+  } catch (pwErr: unknown) {
+    const reason = pwErr instanceof Error ? pwErr.message : String(pwErr);
+    return {
+      ok: false,
+      message: `2FA password check failed: ${reason}. Verify TELEGRAM_2FA_PASSWORD is correct.`,
+    };
+  }
+}
+
 function resolveProxy(): ProxyInterface | undefined {
   const ip = process.env.TELEGRAM_PROXY_IP;
   const port = process.env.TELEGRAM_PROXY_PORT;
@@ -539,29 +584,18 @@ export class TelegramService {
             // The QR was scanned, but the account has two-step verification.
             // Complete the login with an SRP password check if we have the
             // cloud password; otherwise tell the user how to provide it.
-            const password = resolveTwoFactorPassword();
-            if (!password) {
-              await client.disconnect();
-              return {
-                success: false,
-                message:
-                  "2FA is enabled on this account. Set TELEGRAM_2FA_PASSWORD to your cloud password and run login again.",
-              };
-            }
-            try {
-              const passwordInfo = await client.invoke(new Api.account.GetPassword());
-              const check = await computeCheck(passwordInfo, password);
-              await client.invoke(new Api.auth.CheckPassword({ password: check }));
+            const outcome = await completeTwoFactorLogin(client, resolveTwoFactorPassword());
+            if (outcome.ok) {
               resolved = true;
               break;
-            } catch (pwErr: unknown) {
-              await client.disconnect();
-              const reason = pwErr instanceof Error ? pwErr.message : String(pwErr);
-              return {
-                success: false,
-                message: `2FA password check failed: ${reason}. Verify TELEGRAM_2FA_PASSWORD is correct.`,
-              };
             }
+            // destroy() (not disconnect()) to free the auth_key/socket, matching
+            // every other failure exit in this method — important in daemon mode
+            // where the process lives on across logins.
+            try {
+              await client.destroy();
+            } catch {}
+            return { success: false, message: outcome.message };
           }
         }
 

--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -67,6 +67,8 @@ export function registerAuthTools(server: McpServer, telegram: TelegramService) 
         `If the QR image is not visible, it's also saved to: ${qrFilePath}`,
         "",
         "After scanning, run **telegram-status** to verify the connection.",
+        "",
+        "If the account has two-step verification (2FA), set the `TELEGRAM_2FA_PASSWORD` environment variable to the cloud password and log in again — scanning alone cannot complete a 2FA login.",
       ].join("\n");
 
       return {


### PR DESCRIPTION
## Problem

QR login aborts for any account with two-step verification enabled:

```
2FA enabled — QR login not supported with 2FA
```

After the QR is scanned, Telegram imports the login token and then replies
with `SESSION_PASSWORD_NEEDED` for 2FA-protected accounts. The current code
catches that and bails, so these users have no built-in way to log in.

## Change

Handle `SESSION_PASSWORD_NEEDED` inside `startQrLogin` by completing the SRP
password check:

- `account.GetPassword` → `computeCheck(passwordInfo, password)` → `auth.CheckPassword`
- on success, resume the existing session-save path (no other flow changes)

The cloud password is read from a new **`TELEGRAM_2FA_PASSWORD`** env var. Env
was chosen deliberately so the fix works across **all three** login entry
points — standalone CLI, daemon IPC, and the `telegram-login` MCP tool — none
of which can reliably prompt for a password mid-flow. It mirrors how the
project already passes secrets like `TELEGRAM_PROXY_PASSWORD`.

When 2FA is required but the variable is unset, the error message now tells the
user exactly how to supply it, and a wrong password surfaces a clear failure.

## Usage

```bash
TELEGRAM_API_ID=... TELEGRAM_API_HASH=... TELEGRAM_2FA_PASSWORD=... npx @overpod/mcp-telegram login
```