### PR TITLE
fix(resolve): recover bare numeric peer IDs that lack access_hash

### DIFF
--- a/src/__tests__/resolve-numeric-peer.test.ts
+++ b/src/__tests__/resolve-numeric-peer.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import bigInt from "big-integer";
+import { Api } from "telegram/tl/index.js";
+import { TelegramService } from "../telegram-client.js";
+
+/**
+ * Regression tests for numeric-peer resolution. A bare numeric ID (as emitted
+ * by list-chats / search) used to be handed straight to GramJS, which throws
+ * "Could not find the input entity" when the peer isn't cached and the account
+ * is not a contact — and a positive number is ambiguously treated as a PeerUser,
+ * so channel IDs failed outright. resolveNumericPeer recovers by scanning dialogs
+ * for a matching entity (which carries the access_hash), for users AND channels.
+ */
+
+const TMP_DIR = join(tmpdir(), `mcp-telegram-resolvepeer-test-${process.pid}`);
+const SESSION_PATH = join(TMP_DIR, "session");
+
+before(() => mkdirSync(TMP_DIR, { recursive: true }));
+after(() => rmSync(TMP_DIR, { recursive: true, force: true }));
+
+type AnyFn = (...args: unknown[]) => unknown;
+interface MockClient {
+  getEntity: AnyFn;
+  getDialogs: AnyFn;
+}
+
+interface ServiceInternals {
+  client: MockClient | null;
+  connected: boolean;
+  entityCache: Map<string, unknown>;
+  resolveNumericPeer(chatId: string): Promise<unknown>;
+}
+
+function makeService(client: MockClient): ServiceInternals {
+  const svc = new TelegramService(1, "h", { sessionPath: SESSION_PATH });
+  const s = svc as unknown as ServiceInternals;
+  s.client = client;
+  s.connected = true;
+  return s;
+}
+
+const makeUser = (id: number) => new Api.User({ id: bigInt(id), accessHash: bigInt(42), firstName: "U" });
+const makeChannel = (id: number) =>
+  new Api.Channel({
+    id: bigInt(id),
+    title: "C",
+    photo: new Api.ChatPhotoEmpty(),
+    date: 0,
+    accessHash: bigInt(1),
+    megagroup: true,
+  });
+const makeChat = (id: number) =>
+  new Api.Chat({
+    id: bigInt(id),
+    title: "G",
+    photo: new Api.ChatPhotoEmpty(),
+    participantsCount: 1,
+    date: 0,
+    version: 1,
+  });
+
+/** A throw-on-call stub so a test asserts a path is NOT taken. */
+const mustNotBeCalled =
+  (label: string): AnyFn =>
+  () => {
+    throw new Error(`unexpected call: ${label}`);
+  };
+
+const DIRECT_RESOLVE_FAILS: AnyFn = () => {
+  throw new Error("Could not find the input entity");
+};
+
+describe("resolveNumericPeer", () => {
+  it("returns a cached entity without hitting the network", async () => {
+    const entity = makeUser(555);
+    const s = makeService({
+      getEntity: mustNotBeCalled("getEntity"),
+      getDialogs: mustNotBeCalled("getDialogs"),
+    });
+    s.entityCache.set("555", entity);
+
+    const out = await s.resolveNumericPeer("555");
+    assert.strictEqual(out, entity);
+  });
+
+  it("resolves directly via getEntity when GramJS already knows the peer", async () => {
+    const entity = makeUser(777);
+    const s = makeService({
+      getEntity: async (id: unknown) => {
+        assert.strictEqual(id, "777");
+        return entity;
+      },
+      getDialogs: mustNotBeCalled("getDialogs"),
+    });
+
+    const out = await s.resolveNumericPeer("777");
+    assert.strictEqual(out, entity);
+    assert.strictEqual(s.entityCache.get("777"), entity, "result is cached");
+  });
+
+  it("recovers a USER id via dialog scan when direct resolve fails", async () => {
+    const userEntity = makeUser(1282175136);
+    const s = makeService({
+      getEntity: DIRECT_RESOLVE_FAILS,
+      getDialogs: async () => [{ entity: makeChannel(999) }, { entity: userEntity }],
+    });
+
+    const out = await s.resolveNumericPeer("1282175136");
+    assert.strictEqual(out, userEntity, "must return the dialog entity, not the raw id");
+    assert.strictEqual(s.entityCache.get("1282175136"), userEntity);
+  });
+
+  it("recovers a CHANNEL id given BARE (the real prod failure shape)", async () => {
+    // SigNoz showed send-message failing with a bare channelId "1004294063929"
+    // (no -100 prefix) — GramJS treats a bare positive as PeerUser and fails.
+    const channelEntity = makeChannel(1004294063929);
+    const s = makeService({
+      getEntity: DIRECT_RESOLVE_FAILS,
+      getDialogs: async () => [{ entity: channelEntity }],
+    });
+
+    const out = await s.resolveNumericPeer("1004294063929");
+    assert.strictEqual(out, channelEntity);
+  });
+
+  it("recovers a CHANNEL id given in -100… marked form", async () => {
+    const channelEntity = makeChannel(1004294063929);
+    const s = makeService({
+      getEntity: DIRECT_RESOLVE_FAILS,
+      getDialogs: async () => [{ entity: channelEntity }],
+    });
+
+    // Caller passes the marked form; dialog entity carries the bare id.
+    const out = await s.resolveNumericPeer("-1001004294063929");
+    assert.strictEqual(out, channelEntity);
+  });
+
+  it("recovers a basic GROUP id given in -<id> marked form", async () => {
+    const chatEntity = makeChat(123);
+    const s = makeService({
+      getEntity: DIRECT_RESOLVE_FAILS,
+      getDialogs: async () => [{ entity: chatEntity }],
+    });
+
+    const out = await s.resolveNumericPeer("-123");
+    assert.strictEqual(out, chatEntity);
+  });
+
+  it("does NOT cross-match a group id -123 against a user with bare id 123", async () => {
+    // The sign/-100 prefix disambiguates Telegram's overlapping id spaces.
+    // A naive bare compare would wrongly return this user; the marked compare must not.
+    const s = makeService({
+      getEntity: DIRECT_RESOLVE_FAILS,
+      getDialogs: async () => [{ entity: makeUser(123) }],
+    });
+
+    const out = await s.resolveNumericPeer("-123");
+    assert.strictEqual(out, "-123", "no marked match → raw-id fallback, not the user 123");
+  });
+
+  it("falls back to the raw id string when no dialog matches", async () => {
+    const s = makeService({
+      getEntity: DIRECT_RESOLVE_FAILS,
+      getDialogs: async () => [{ entity: makeUser(111) }],
+    });
+
+    const out = await s.resolveNumericPeer("222");
+    assert.strictEqual(out, "222", "must not regress the GramJS GetUsers path for contacts");
+  });
+
+  it("falls back to the raw id when the dialog fetch itself throws", async () => {
+    const s = makeService({
+      getEntity: DIRECT_RESOLVE_FAILS,
+      getDialogs: async () => {
+        throw new Error("network down");
+      },
+    });
+
+    const out = await s.resolveNumericPeer("333");
+    assert.strictEqual(out, "333");
+  });
+});

--- a/src/telegram-client.ts
+++ b/src/telegram-client.ts
@@ -1581,10 +1581,72 @@ export class TelegramService {
   private async resolvePeer(chatId: string): Promise<string | ChatEntity> {
     // Normalize '@me' — GramJS only intercepts the plain 'me' string as InputPeerSelf
     if (chatId === "@me") return "me";
-    // Numeric IDs and @usernames work directly
-    if (/^-?\d+$/.test(chatId) || chatId.startsWith("@")) return chatId;
-    // Everything else — resolve via dialogs
+    // @usernames resolve directly via contacts.ResolveUsername
+    if (chatId.startsWith("@")) return chatId;
+    // Bare numeric IDs need an entity with access_hash. GramJS can build an
+    // InputPeer from a raw number only if it's already cached or the account
+    // is a contact / has messaged us — otherwise getInputEntity throws
+    // "Could not find the input entity". A bare positive number is also
+    // ambiguous (GramJS assumes PeerUser, so channel IDs fail outright).
+    // Recover by looking the ID up among dialogs, which yields a full entity
+    // (with access_hash) for both users and channels.
+    if (/^-?\d+$/.test(chatId)) return this.resolveNumericPeer(chatId);
+    // Everything else — resolve display name via dialogs
     return this.resolveChat(chatId);
+  }
+
+  /**
+   * Resolve a bare numeric ID to a cached/dialog entity so GramJS can build a
+   * valid InputPeer. Falls back to the raw ID string if no dialog matches —
+   * GramJS may still resolve it (e.g. a contact or a peer it has messaged),
+   * and we must not regress that path.
+   */
+  private async resolveNumericPeer(chatId: string): Promise<string | ChatEntity> {
+    if (!this.client) throw new Error(NOT_CONNECTED_ERROR);
+
+    const cached = this.entityCache.get(chatId);
+    if (cached) return cached;
+
+    // Direct resolve first — succeeds when GramJS already knows the peer.
+    try {
+      const entity = await this.client.getEntity(chatId);
+      this.entityCache.set(chatId, entity);
+      return entity;
+    } catch {
+      // Fall through to dialog scan.
+    }
+
+    // Scan dialogs for a matching entity. IDs reach us in two shapes:
+    //   • bare positive  (e.g. 1004294063929 for a channel, 8959122940 for a
+    //     user) — this is what list-chats/search emit and what GramJS can't
+    //     disambiguate; match it against any entity's bare id.
+    //   • marked         (-100<id> for channels, -<id> for basic groups) — the
+    //     sign/-100 prefix carries the type, so require the entity to match that
+    //     exact marked form, otherwise a group "-123" could wrongly match a user
+    //     with bare id 123.
+    const isMarked = chatId.startsWith("-");
+    try {
+      const dialogs = await this.client.getDialogs({ limit: 100 });
+      const match = dialogs.find((d) => {
+        const entity = d.entity;
+        if (!entity?.id) return false;
+        const bare = entity.id.toString();
+        if (!isMarked) return chatId === bare;
+        // Marked input must match the entity's marked form.
+        if (entity instanceof Api.Channel) return chatId === `-100${bare}`;
+        if (entity instanceof Api.Chat) return chatId === `-${bare}`;
+        return false;
+      });
+      if (match?.entity) {
+        this.entityCache.set(chatId, match.entity);
+        return match.entity;
+      }
+    } catch {
+      // Dialog fetch failed — fall back to the raw ID below.
+    }
+
+    // Last resort: hand the raw ID to GramJS and let it try GetUsers/GetChannels.
+    return chatId;
   }
 
   async getChatInfo(chatId: string): Promise<{


### PR DESCRIPTION
## Problem

`telegram-read-messages` / `telegram-send-message` fail with **"Could not find the input entity"** when given a bare numeric ID. Prod telemetry (SigNoz) shows ~16 such failures/month — ~6% of read/send calls, the single largest error class on the hosted service.

**Root cause:** `list-chats`/`search` emit **bare** numeric IDs (`peer.userId/channelId.toString()`, no marker). When the LLM passes one back, `resolvePeer` returned it raw, and GramJS `getInputEntity` treats a bare positive as a `PeerUser` → channel IDs fail outright, and user IDs only resolve for contacts / peers who messaged us. Without an `access_hash` no `InputPeer` can be built.

## Fix

Numeric IDs now route through `resolveNumericPeer`:
1. cache hit → return;
2. `getEntity` direct (works when GramJS already knows the peer);
3. **scan dialogs** for a matching entity — bare positive matches any entity's bare id (recovers users *and* channels); marked `-100<id>`/`-<id>` must match that exact type, so a group `-123` can't mis-match a user `123`. The matched entity carries `access_hash`.
4. fall back to the raw ID string → preserves the GramJS `GetUsers` path for contacts.

Strictly additive — every previously-working case still works.

## Tests

`src/__tests__/resolve-numeric-peer.test.ts` — 9 cases incl. the real bare-channel prod shape, marked-channel, marked-group, and the cross-space collision guard.

**Gates:** lint ✅ · typecheck ✅ · 527 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)