### PR TITLE
feat(media): add thumbnail option to downloadMediaAsBuffer

### DIFF
--- a/src/__tests__/download-media-thumb.test.ts
+++ b/src/__tests__/download-media-thumb.test.ts
@@ -55,6 +55,7 @@ describe("downloadMediaAsBuffer thumb support", () => {
     const res = await svc.downloadMediaAsBuffer("@test", 1, { thumb: 0 });
     assert.equal(seen, 0, "thumb index forwarded to GramJS");
     assert.deepEqual(res.buffer, THUMB);
+    assert.equal(res.mimeType, "image/jpeg", "mime detected from thumbnail bytes");
     assert.equal(res.isThumb, true);
   });
 
@@ -64,5 +65,21 @@ describe("downloadMediaAsBuffer thumb support", () => {
     const res = await svc.downloadMediaAsBuffer("@test", 1, { thumb: 0 });
     assert.deepEqual(res.buffer, JPEG, "fell back to full file bytes");
     assert.equal(res.isThumb, false, "isThumb false since full file was served");
+  });
+
+  it("falls back to the full file when the thumb download yields an empty buffer", async () => {
+    // GramJS returns Buffer.alloc(0) (truthy!) on some no-thumb paths — must
+    // still fall back to the full file, not return 0 bytes as success.
+    const svc = makeService({ full: JPEG, thumbResult: Buffer.alloc(0) });
+    const res = await svc.downloadMediaAsBuffer("@test", 1, { thumb: 0 });
+    assert.deepEqual(res.buffer, JPEG, "empty thumb buffer fell back to full file");
+    assert.equal(res.isThumb, false);
+  });
+
+  it("throws when the full download yields an empty buffer (undownloadable media)", async () => {
+    // GramJS returns Buffer.alloc(0) for geo/poll/dice and failure paths.
+    // An empty Buffer is truthy, so a naive !buffer guard would let it through.
+    const svc = makeService({ full: Buffer.alloc(0) });
+    await assert.rejects(() => svc.downloadMediaAsBuffer("@test", 1), /Failed to download media/);
   });
 });

--- a/src/__tests__/download-media-thumb.test.ts
+++ b/src/__tests__/download-media-thumb.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { TelegramService } from "../telegram-client.js";
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+interface Internals {
+  client: unknown;
+  connected: boolean;
+}
+
+// Minimal JPEG so detectMimeType() returns "image/jpeg" from magic bytes.
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0x00, 0x01, 0x02]);
+const THUMB = Buffer.from([0xff, 0xd8, 0xff, 0x00]); // smaller "thumbnail"
+
+/**
+ * Build a service whose fake client returns `full` for a normal download and
+ * `thumbResult` when a thumb is requested. `thumbResult: undefined` simulates
+ * media that has no thumbnail at the requested size (GramJS returns undefined).
+ */
+function makeService(opts: {
+  full: Buffer;
+  thumbResult?: Buffer;
+  recordThumb?: (thumb: unknown) => void;
+}): TelegramService {
+  const fakeClient = {
+    getMessages: async () => [{ media: { _: "messageMediaPhoto" } }],
+    downloadMedia: async (_message: unknown, params?: { thumb?: number }) => {
+      if (params?.thumb !== undefined) {
+        opts.recordThumb?.(params.thumb);
+        return opts.thumbResult;
+      }
+      return opts.full;
+    },
+  };
+  const service = new TelegramService(1, "hash");
+  const internals = service as unknown as Internals;
+  internals.client = fakeClient;
+  internals.connected = true;
+  return service;
+}
+
+describe("downloadMediaAsBuffer thumb support", () => {
+  it("returns the full file when no thumb is requested", async () => {
+    const svc = makeService({ full: JPEG });
+    const res = await svc.downloadMediaAsBuffer("@test", 1);
+    assert.deepEqual(res.buffer, JPEG);
+    assert.equal(res.mimeType, "image/jpeg");
+    assert.equal(res.isThumb, false);
+  });
+
+  it("returns the thumbnail and flags isThumb when thumb is available", async () => {
+    let seen: unknown;
+    const svc = makeService({ full: JPEG, thumbResult: THUMB, recordThumb: (t) => (seen = t) });
+    const res = await svc.downloadMediaAsBuffer("@test", 1, { thumb: 0 });
+    assert.equal(seen, 0, "thumb index forwarded to GramJS");
+    assert.deepEqual(res.buffer, THUMB);
+    assert.equal(res.isThumb, true);
+  });
+
+  it("falls back to the full file when the media has no thumbnail at that size", async () => {
+    // GramJS returns undefined for thumb when none exists — must not throw.
+    const svc = makeService({ full: JPEG, thumbResult: undefined });
+    const res = await svc.downloadMediaAsBuffer("@test", 1, { thumb: 0 });
+    assert.deepEqual(res.buffer, JPEG, "fell back to full file bytes");
+    assert.equal(res.isThumb, false, "isThumb false since full file was served");
+  });
+});

--- a/src/telegram-client.ts
+++ b/src/telegram-client.ts
@@ -1014,8 +1014,16 @@ export class TelegramService {
    * the full file (`0` = smallest, larger indexes = bigger previews). This keeps
    * payloads tiny — useful for callers that inline the bytes and pay per byte
    * (e.g. base64 in an LLM context). If the message has no thumbnail at that
-   * index, GramJS returns `undefined`; we transparently fall back to the full
-   * file so the caller always gets bytes. `isThumb` reports which one was served.
+   * index, GramJS returns an empty/`undefined` buffer; we transparently fall
+   * back to the full file so the caller always gets bytes. `isThumb` reports
+   * which one was served.
+   *
+   * Note: GramJS signals "no bytes" inconsistently — `undefined` for a missing
+   * thumbnail, but `Buffer.alloc(0)` for undownloadable media (geo/poll/dice,
+   * documents without a file, and several failure paths). An empty Buffer is
+   * truthy, so we guard on `.length`, not truthiness, in both the fallback and
+   * the final failure check — otherwise a 0-byte buffer would be returned as a
+   * "successful" (but garbage) download.
    */
   async downloadMediaAsBuffer(
     chatId: string,
@@ -1033,11 +1041,11 @@ export class TelegramService {
     let buffer: Buffer | undefined;
     if (options?.thumb !== undefined) {
       buffer = (await this.client.downloadMedia(message, { thumb: options.thumb })) as Buffer | undefined;
-      isThumb = !!buffer;
+      isThumb = !!buffer?.length;
     }
     // No thumb requested, or this media has no thumbnail at that size → full file.
-    if (!buffer) buffer = (await this.client.downloadMedia(message)) as Buffer;
-    if (!buffer) throw new Error("Failed to download media");
+    if (!buffer?.length) buffer = (await this.client.downloadMedia(message)) as Buffer;
+    if (!buffer?.length) throw new Error("Failed to download media");
 
     const mimeType = this.detectMimeType(buffer, message.media);
     return { buffer, mimeType, isThumb };

--- a/src/telegram-client.ts
+++ b/src/telegram-client.ts
@@ -1007,17 +1007,40 @@ export class TelegramService {
     return downloadPath;
   }
 
-  async downloadMediaAsBuffer(chatId: string, messageId: number): Promise<{ buffer: Buffer; mimeType: string }> {
+  /**
+   * Download a message's media into memory.
+   *
+   * When `options.thumb` is given, GramJS fetches that thumbnail size instead of
+   * the full file (`0` = smallest, larger indexes = bigger previews). This keeps
+   * payloads tiny — useful for callers that inline the bytes and pay per byte
+   * (e.g. base64 in an LLM context). If the message has no thumbnail at that
+   * index, GramJS returns `undefined`; we transparently fall back to the full
+   * file so the caller always gets bytes. `isThumb` reports which one was served.
+   */
+  async downloadMediaAsBuffer(
+    chatId: string,
+    messageId: number,
+    options?: { thumb?: number },
+  ): Promise<{ buffer: Buffer; mimeType: string; isThumb: boolean }> {
     if (!this.client || !this.connected) throw new Error(NOT_CONNECTED_ERROR);
     const resolved = await this.resolvePeer(chatId);
     const messages = await this.client.getMessages(resolved, { ids: [messageId] });
     const message = messages[0];
     if (!message) throw new Error(`Message ${messageId} not found`);
     if (!message.media) throw new Error(`Message ${messageId} has no media`);
-    const buffer = (await this.client.downloadMedia(message)) as Buffer;
+
+    let isThumb = false;
+    let buffer: Buffer | undefined;
+    if (options?.thumb !== undefined) {
+      buffer = (await this.client.downloadMedia(message, { thumb: options.thumb })) as Buffer | undefined;
+      isThumb = !!buffer;
+    }
+    // No thumb requested, or this media has no thumbnail at that size → full file.
+    if (!buffer) buffer = (await this.client.downloadMedia(message)) as Buffer;
     if (!buffer) throw new Error("Failed to download media");
+
     const mimeType = this.detectMimeType(buffer, message.media);
-    return { buffer, mimeType };
+    return { buffer, mimeType, isThumb };
   }
 
   /** Detect MIME type from buffer magic bytes, falling back to media metadata */


### PR DESCRIPTION
## Why

`downloadMediaAsBuffer` always fetched the **full** file. Callers that inline the bytes — notably the cloud server, which returns the image as base64 in the LLM context — pay per byte. A single ~950 KB photo costs **hundreds of thousands of tokens**.

Observed in production (SigNoz): a power user ran a channel-scraping session that hit `telegram-download-media` **267 times (72% of the session)** and burned **~1.5M tokens** — the dominant token sink, not feed-reading.

## What

- Add an optional `{ thumb }` arg to `downloadMediaAsBuffer` — fetches a Telegram thumbnail size instead of the full file (`0` = smallest preview).
- **Safe fallback:** GramJS returns `undefined` when the media has no thumbnail at that index; we transparently fall back to the full file so callers always get bytes.
- New `isThumb` flag in the return reports which one was served.
- **Default behavior unchanged** — no `thumb` → full file, as before. Purely additive.

This is the OSS half. The cloud consumer will use `thumb` as the default for `telegram-download-media` (full image opt-in via `full: true`), cutting per-call token cost 10–50× for the common case.

## Tests

+3 unit tests (`download-media-thumb.test.ts`): full-file default, thumb served + index forwarded, and the no-thumbnail fallback path. Full suite green (530 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)